### PR TITLE
Fix auto-merge workflow for fork PRs

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,8 +1,8 @@
 name: Auto-merge
 
 on:
-  pull_request:
-    types: [opened, ready_for_review]
+  pull_request_target:
+    types: [opened, reopened, ready_for_review]
 
 permissions:
   contents: write


### PR DESCRIPTION
Use pull_request_target to get write permissions for fork PRs, and add reopened trigger.

Assisted-by: Claude