### PR TITLE
Allow model overrides via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,11 @@ Two-tier approach configured in `config.py`:
 - **Flash** (fast): Fetch nodes (`fetch_veps`, `check_*`).
 - **Pro** (powerful): Analysis nodes (`analyze_combined`, `update_sheets`, `alert_summary`).
 
+Override models via environment variables:
+- `FAST_MODEL` (default: `gemini-3-flash-preview`)
+- `HEAVY_MODEL` (default: `gemini-3.1-pro-preview`)
+- `DEFAULT_MODEL` (default: same as `FAST_MODEL`)
+
 Use `--fastest-model` to force Flash everywhere for testing.
 
 ### Google Sheets

--- a/config/util.py
+++ b/config/util.py
@@ -3,11 +3,11 @@
 import os
 from typing import Dict, List, Optional
 
-# Model tier constants for node configuration
-FAST_MODEL = "gemini-3-flash-preview"
-HEAVY_MODEL = "gemini-3.1-pro-preview"
+# Model tier constants for node configuration (overridable via env vars)
+FAST_MODEL = os.getenv("FAST_MODEL", "gemini-3-flash-preview")
+HEAVY_MODEL = os.getenv("HEAVY_MODEL", "gemini-3.1-pro-preview")
 
-DEFAULT_MODEL = FAST_MODEL
+DEFAULT_MODEL = os.getenv("DEFAULT_MODEL", FAST_MODEL)
 
 AVAILABLE_MODELS = [
     FAST_MODEL,


### PR DESCRIPTION
## Summary
- `FAST_MODEL`, `HEAVY_MODEL`, and `DEFAULT_MODEL` can now be overridden via environment variables, making it easy to swap models without code changes
- Follow-up on PR #11 review feedback from @vladikr ([comment](https://github.com/iholder101/vep-police-agent/pull/11#discussion_r2874028110))
