### PR TITLE
Add diff-based testing via deterministic status snapshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ cache/*
 !cache/history/
 cache/history/*
 !cache/history/.gitkeep
+output/

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ graph TD
     Scheduler -->|Board due| UpdateBoard[update_project_board]
     Scheduler -->|Alerts due| AlertSummary[alert_summary]
     Scheduler -->|No tasks| Wait[wait]
+    Scheduler -->|one-cycle done| End([END])
 
     FetchVEPs --> Scheduler
 
@@ -169,6 +170,7 @@ sudo ./scripts/create-systemd-unit.sh --delete
 podman run --rm --pull=newer \
     -v "$(pwd):/workspace:ro" \
     -v "$(pwd)/cache:/workspace/cache:rw" \
+    -v "$(pwd)/output:/workspace/output:rw" \
     -w /workspace \
     quay.io/mabekitzur/vep-police-agent:latest \
     --api-key /workspace/API_KEY \
@@ -181,6 +183,7 @@ podman run --rm --pull=newer \
 **Note**:
 - `-v "$(pwd):/workspace:ro"` mounts your project directory as read-only (credentials stay secure)
 - `-v "$(pwd)/cache:/workspace/cache:rw"` mounts cache directory as read-write for persistence
+- `-v "$(pwd)/output:/workspace/output:rw"` mounts output directory for status snapshots
 - `-w /workspace` sets the working directory so `/workspace/API_KEY` paths work correctly
 - Run this from the project root directory where your credential files are located
 
@@ -296,6 +299,43 @@ Cache files in `cache/` directory:
 - `alert_persistence.json`: Tracks escalation logic.
 
 Use `--clear-history` for a fresh start.
+
+## Status Snapshots & Diff-Based Testing
+
+Each agent cycle produces deterministic output files in `output/`:
+
+| File | Description |
+|------|-------------|
+| `vep_snapshot_YYYYMMDD_HHMM.yaml` | Timestamped VEP status (sorted, fixed field order). Last 10 kept. |
+| `realizations.txt` | Changes vs previous run + anomaly flags |
+
+**Diff-based review workflow:**
+
+```bash
+# Diff the two most recent snapshots
+diff output/vep_snapshot_20260330_1400.yaml output/vep_snapshot_20260331_1400.yaml
+
+# Or read the realizations file directly (auto-diffs the last two snapshots)
+cat output/realizations.txt
+```
+
+The realizations file flags anomalies automatically (VEPs disappearing, PR counts
+decreasing, compliance regressions, large merge probability swings) - no LLM involved,
+purely deterministic checks.
+
+**Snapshot validation** (integration test equivalent):
+
+```bash
+# Run a full cycle with output-only flags
+python main.py --one-cycle \
+  --api-key API_KEY --google-token GOOGLE_TOKEN \
+  --github-token GITHUB_TOKEN --skip-sheets --skip-send-email \
+  --skip-send-slack --skip-update-board
+
+# Verify output files exist and look correct
+ls output/vep_snapshot_*.yaml
+cat output/realizations.txt
+```
 
 ## Troubleshooting
 

--- a/graph.py
+++ b/graph.py
@@ -1,7 +1,7 @@
 """LangGraph definition for VEP governance agent."""
 
 from typing import Literal, Any
-from langgraph.graph import StateGraph
+from langgraph.graph import StateGraph, END
 from langgraph.graph.state import CompiledStateGraph
 
 from state import VEPState
@@ -83,6 +83,7 @@ def create_graph() -> CompiledStateGraph[Any, Any, Any, Any]:
             "update_project_board": "update_project_board",
             "alert_summary": "alert_summary",
             "wait": "wait",
+            END: END,
         }
     )
     
@@ -138,9 +139,9 @@ def create_graph() -> CompiledStateGraph[Any, Any, Any, Any]:
     return workflow.compile()
 
 
-def route_scheduler_operations(state: VEPState) -> Literal["fetch_veps", "run_monitoring", "update_sheets", "update_project_board", "alert_summary", "wait"]:
+def route_scheduler_operations(state: VEPState) -> str:
     """Route based on scheduler's next_tasks.
-    
+
     Routes to the first task in the queue. The scheduler can queue:
     - "fetch_veps" (discovers/updates VEPs from GitHub)
     - "run_monitoring" (triggers all checks in parallel) - only if not skip_monitoring
@@ -148,17 +149,16 @@ def route_scheduler_operations(state: VEPState) -> Literal["fetch_veps", "run_mo
     - "update_project_board" (writes summary data to GitHub project board)
     - "alert_summary" (checks if alerts need to be sent)
     - "wait" (wait until next round hour)
-    
+
     Note: Multiple tasks (e.g., update_sheets and alert_summary) are handled
     by routing to them sequentially. The scheduler queues tasks and processes
     them one at a time, returning to scheduler after each completes.
     """
     import os
     debug_mode = os.environ.get("DEBUG_MODE")
-    # In one-cycle mode or test-sheets debug mode, if sheet update completed, exit (don't route to wait)
+    # In one-cycle mode or test-sheets debug mode, if sheet update completed, terminate the graph
     if (state.get("one_cycle", False) or debug_mode == "test-sheets") and state.get("_exit_after_sheets", False):
-        # Don't route anywhere - main loop will detect this and exit
-        return "wait"  # Return wait but wait node will exit immediately
+        return END
     
     next_tasks = state.get("next_tasks", [])
     

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ import json
 import os
 import signal
 import sys
+import time
 from pathlib import Path
 from typing import Optional, Dict, Any
 from langchain_core.messages import HumanMessage
@@ -14,6 +15,7 @@ from services.utils import log
 from state import VEPInfo, ReleaseSchedule
 from nodes.state_history import clear_all_history
 from nodes.escalation import clear_persistence
+from nodes.snapshot import dump_snapshot, generate_realizations
 
 # State cache file location
 STATE_CACHE_FILE = Path(__file__).parent / "cache" / "state_cache.json"
@@ -420,6 +422,16 @@ def setup_credentials(args):
         log("Fastest model mode enabled: all nodes will use FAST_MODEL", node="main")
 
 
+def _try_snapshot(response, start_time: float) -> None:
+    """Write snapshot and realizations, swallowing errors."""
+    try:
+        elapsed = time.time() - start_time
+        dump_snapshot(response, cycle_duration=elapsed)
+        generate_realizations(response, cycle_duration=elapsed)
+    except Exception as e:
+        log(f"Snapshot failed: {e}", node="main", level="ERROR")
+
+
 def main():
     """Run the VEP governance agent."""
     global _shutdown_requested
@@ -501,6 +513,8 @@ def main():
     log(f"Sheet config: {initial_state['sheet_config']}", node="main")
     
     # Run the agent
+    start_time = time.time()
+    response = initial_state  # Ensure response is always defined for finally block
     try:
         if args.one_cycle:
             # In one-cycle mode, run until update_sheets completes
@@ -508,40 +522,41 @@ def main():
             current_state = initial_state
             max_iterations = 50  # Safety limit
             iteration = 0
-            
+
             while iteration < max_iterations:
                 iteration += 1
                 response = agent.invoke(current_state)
-                
+
                 if _shutdown_requested:
                     log("Agent interrupted by user. Exiting...", node="main", level="INFO")
                     return
-                
+
                 # Check if we should exit after sheet update
                 if response.get("_exit_after_sheets", False):
                     log("One-cycle mode: Sheet update completed, exiting", node="main")
-                    return  # Exit immediately
-                
+                    return
+
                 # Update state for next iteration
                 current_state = response
-                
+
                 # Safety check: if no tasks are scheduled and sheets don't need update, exit
                 if not response.get("next_tasks") and not response.get("sheets_need_update", False):
                     log("No more tasks scheduled and sheets are up to date, exiting", node="main")
                     return
             log(f"One-cycle mode: Reached max iterations ({max_iterations}), exiting", node="main", level="WARNING")
+            return
         else:
             # Normal mode - run continuously
             log("Invoking agent...", node="main")
             response = agent.invoke(initial_state)
-        
+
         if _shutdown_requested:
             log("Agent interrupted by user. Exiting...", node="main", level="INFO")
             return
-        
+
         log("Agent execution completed", node="main")
         log(f"Final state keys: {list(response.keys())}", node="main")
-        
+
         # Check if sheet was created
         sheet_config = response.get("sheet_config", {})
         if sheet_config.get("sheet_id"):
@@ -549,7 +564,7 @@ def main():
             log(f"  View at: https://docs.google.com/spreadsheets/d/{sheet_config['sheet_id']}/edit", node="main")
         else:
             log("Sheet ID not yet set - will be created on first update_sheets run", node="main")
-            
+
     except KeyboardInterrupt:
         log("\nInterrupted by user. Exiting gracefully...", node="main", level="INFO")
         sys.exit(130)
@@ -561,6 +576,8 @@ def main():
         import traceback
         log(f"Traceback: {traceback.format_exc()}", node="main", level="ERROR")
         raise
+    finally:
+        _try_snapshot(response, start_time)
 
 
 if __name__ == "__main__":

--- a/nodes/snapshot.py
+++ b/nodes/snapshot.py
@@ -1,0 +1,391 @@
+"""Deterministic VEP status snapshot and self-consistency realizations.
+
+Produces diff-friendly output files after each agent cycle:
+- output/vep_snapshot_YYYYMMDD_HHMM.yaml - timestamped VEP status
+- output/realizations.txt - changes and anomalies vs previous run
+
+Keeps the last 10 snapshots, older ones are pruned automatically.
+"""
+
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import yaml
+
+from services.utils import log
+from state import VEPState
+
+OUTPUT_DIR = Path(__file__).parent.parent / "output"
+
+# Compliance field display names -> VEPCompliance attribute names
+_COMPLIANCE_FIELDS = {
+    "template": "template_complete",
+    "sigs-signed-off": "all_sigs_signed_off",
+    "vep-merged": "vep_merged",
+    "prs-linked": "prs_linked",
+    "docs-pr": "docs_pr_created",
+    "labels": "labels_valid",
+}
+
+# Alert severity ordering (lower = higher priority)
+_SEVERITY_ORDER = {"critical": 0, "high": 1, "medium": 2, "low": 3}
+
+# Merge probability change threshold (percentage points) for anomaly detection
+_MERGE_PROB_ANOMALY_THRESHOLD = 40
+
+# Maximum number of snapshot files to keep
+_MAX_SNAPSHOTS = 10
+
+
+def dump_snapshot(state: VEPState, cycle_duration: float = 0) -> None:
+    """Write deterministic VEP status snapshot to output/."""
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    veps = state.get("veps", [])
+    summary_table = state.get("vep_summary_table", [])
+    alerts = state.get("alerts", [])
+    release_schedule = state.get("release_schedule")
+    now = datetime.now()
+
+    # Build urgency lookup from summary table
+    urgency_by_vep = {}
+    for row in summary_table:
+        vep_num = row.get("vep_number")
+        if vep_num is not None:
+            urgency_by_vep[vep_num] = row.get("urgency")
+
+    # Build alerts lookup by VEP ID
+    alerts_by_vep: Dict[int, List[Dict[str, Any]]] = {}
+    for alert in alerts:
+        vep_id = alert.get("vep_id")
+        if vep_id is not None:
+            alerts_by_vep.setdefault(vep_id, []).append(alert)
+
+    # Deadline info from release schedule
+    ef_date = None
+    cf_date = None
+    if release_schedule:
+        ef_date = release_schedule.enhancement_freeze
+        cf_date = release_schedule.code_freeze
+
+    # Build snapshot data sorted by tracking_issue_id
+    sorted_veps = sorted(veps, key=lambda v: v.tracking_issue_id)
+    vep_records = []
+
+    for vep in sorted_veps:
+        record = _build_vep_record(
+            vep, urgency_by_vep, alerts_by_vep, ef_date, cf_date, now
+        )
+        vep_records.append(record)
+
+    snapshot = {
+        "generated": now.strftime("%Y-%m-%dT%H:%M:%S"),
+        "cycle_duration_seconds": round(cycle_duration),
+        "vep_count": len(vep_records),
+        "veps": vep_records,
+    }
+
+    # Write timestamped YAML
+    timestamp = now.strftime("%Y%m%d_%H%M")
+    yaml_path = OUTPUT_DIR / f"vep_snapshot_{timestamp}.yaml"
+    yaml_path.write_text(yaml.dump(snapshot, default_flow_style=False, sort_keys=False, allow_unicode=True))
+
+    # Prune old snapshots
+    _prune_snapshots()
+
+    log(f"Snapshot written: {len(vep_records)} VEPs", node="snapshot")
+
+
+def generate_realizations(state: VEPState, cycle_duration: float = 0) -> None:
+    """Compare current vs previous snapshot, write output/realizations.txt."""
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    snapshots = _get_sorted_snapshots()
+    now = datetime.now()
+
+    if not snapshots:
+        log("No snapshots found, skipping realizations", node="snapshot")
+        return
+
+    current = yaml.safe_load(snapshots[-1].read_text())
+
+    if len(snapshots) < 2:
+        lines = [
+            f"Generated: {now.strftime('%Y-%m-%dT%H:%M:%S')} | cycle: {round(cycle_duration)}s",
+            "",
+            "=== Changes ===",
+            "First run - no previous data",
+            "",
+            "=== Anomalies ===",
+            "(none)",
+            "",
+        ]
+        (OUTPUT_DIR / "realizations.txt").write_text("\n".join(lines))
+        log("Realizations written (first run)", node="snapshot")
+        return
+
+    previous = yaml.safe_load(snapshots[-2].read_text())
+    changes, anomalies = _diff_snapshots(previous, current)
+
+    lines = [
+        f"Generated: {now.strftime('%Y-%m-%dT%H:%M:%S')} | cycle: {round(cycle_duration)}s",
+        "",
+        "=== Changes ===",
+    ]
+    if changes:
+        lines.extend(f"- {c}" for c in changes)
+    else:
+        lines.append("(no changes)")
+    lines.append("")
+    lines.append("=== Anomalies ===")
+    if anomalies:
+        lines.extend(f"- {a}" for a in anomalies)
+    else:
+        lines.append("(none)")
+    lines.append("")
+
+    (OUTPUT_DIR / "realizations.txt").write_text("\n".join(lines))
+    log(f"Realizations written: {len(changes)} changes, {len(anomalies)} anomalies",
+        node="snapshot")
+
+
+# -- Internal helpers --
+
+
+def _build_vep_record(
+    vep, urgency_by_vep, alerts_by_vep, ef_date, cf_date, now
+) -> Dict[str, Any]:
+    """Build a single VEP record for the snapshot."""
+    vep_num = vep.tracking_issue_id
+
+    # Sentiment and merge probability from analysis
+    risk = vep.analysis.get("risk_assessment", {}) if vep.analysis else {}
+    sentiment = risk.get("reviewer_sentiment", "unknown")
+    merge_prob = risk.get("merge_probability")
+    if merge_prob is not None:
+        try:
+            merge_prob = int(merge_prob)
+        except (ValueError, TypeError):
+            merge_prob = None
+
+    # Compliance
+    compliance = {}
+    for display_name, attr_name in _COMPLIANCE_FIELDS.items():
+        key = display_name.replace("-", "_")
+        compliance[key] = getattr(vep.compliance, attr_name, False) if vep.compliance else False
+
+    # Activity
+    days_since_update = vep.activity.days_since_update if vep.activity else None
+    review_lag_days = vep.activity.review_lag_days if vep.activity else None
+
+    # Deadlines with pre-computed day deltas
+    deadlines = {}
+    if ef_date:
+        deadlines["ef"] = ef_date.strftime("%Y-%m-%d") if hasattr(ef_date, "strftime") else str(ef_date)
+        try:
+            deadlines["ef_days"] = (ef_date - now).days
+        except TypeError:
+            pass
+    if cf_date:
+        deadlines["cf"] = cf_date.strftime("%Y-%m-%d") if hasattr(cf_date, "strftime") else str(cf_date)
+        try:
+            deadlines["cf_days"] = (cf_date - now).days
+        except TypeError:
+            pass
+
+    # PRs
+    proposal_prs = _format_pr_list(vep.enhancement_prs)
+    impl_prs = _format_pr_list(vep.implementation_prs)
+
+    # Alerts for this VEP
+    vep_alerts = alerts_by_vep.get(vep_num, [])
+    formatted_alerts = _format_alert_list(vep_alerts)
+
+    # Milestone info
+    milestone = vep.current_milestone
+    promotion_phase = milestone.promotion_phase if milestone else None
+    status = milestone.status if milestone else vep.status
+
+    return {
+        "vep_number": vep_num,
+        "name": vep.name,
+        "title": vep.title,
+        "owner": vep.owner,
+        "sig": vep.owning_sig,
+        "target_release": vep.target_release,
+        "status": status,
+        "promotion_phase": promotion_phase,
+        "urgency": urgency_by_vep.get(vep_num),
+        "merge_probability": merge_prob,
+        "sentiment": sentiment,
+        "compliance": compliance,
+        "days_since_update": days_since_update,
+        "review_lag_days": review_lag_days,
+        "deadlines": deadlines,
+        "proposal_prs": proposal_prs,
+        "impl_prs": impl_prs,
+        "alerts": formatted_alerts,
+    }
+
+
+def _format_pr_list(prs) -> List[Dict[str, Any]]:
+    """Format PR list sorted by number."""
+    if not prs:
+        return []
+    sorted_prs = sorted(prs, key=lambda p: p.number)
+    result = []
+    for pr in sorted_prs:
+        state = "unknown"
+        if pr.merged:
+            state = "merged"
+        elif pr.state:
+            state = pr.state.lower()
+        result.append({"number": pr.number, "state": state})
+    return result
+
+
+def _format_alert_list(alerts: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Format alert list sorted by severity then subject."""
+    if not alerts:
+        return []
+    sorted_alerts = sorted(
+        alerts,
+        key=lambda a: (_SEVERITY_ORDER.get(a.get("severity", "low"), 99), a.get("subject", "")),
+    )
+    return [
+        {
+            "severity": a.get("severity", "low"),
+            "subject": a.get("subject", ""),
+            "message": a.get("message", ""),
+        }
+        for a in sorted_alerts
+    ]
+
+
+def _get_sorted_snapshots() -> List[Path]:
+    """Return snapshot files sorted by timestamp (oldest first)."""
+    return sorted(OUTPUT_DIR.glob("vep_snapshot_*.yaml"))
+
+
+def _prune_snapshots() -> None:
+    """Remove oldest snapshots, keeping the last _MAX_SNAPSHOTS."""
+    snapshots = _get_sorted_snapshots()
+    for old in snapshots[:-_MAX_SNAPSHOTS]:
+        old.unlink()
+
+
+def _diff_snapshots(
+    previous: Dict[str, Any], current: Dict[str, Any]
+) -> tuple[List[str], List[str]]:
+    """Diff two snapshot JSONs, return (changes, anomalies)."""
+    changes: List[str] = []
+    anomalies: List[str] = []
+
+    prev_veps = {v["vep_number"]: v for v in previous.get("veps", [])}
+    curr_veps = {v["vep_number"]: v for v in current.get("veps", [])}
+
+    prev_nums = set(prev_veps.keys())
+    curr_nums = set(curr_veps.keys())
+
+    # New VEPs
+    for num in sorted(curr_nums - prev_nums):
+        changes.append(f"VEP-{num:04d}: new VEP appeared")
+
+    # Disappeared VEPs
+    for num in sorted(prev_nums - curr_nums):
+        changes.append(f"VEP-{num:04d}: VEP disappeared")
+        anomalies.append(f"VEP-{num:04d}: was in previous run but missing now (VEPs should not disappear)")
+
+    # Compare existing VEPs
+    for num in sorted(prev_nums & curr_nums):
+        pv = prev_veps[num]
+        cv = curr_veps[num]
+        vep_id = f"VEP-{num:04d}"
+
+        # Scalar fields
+        # Exclude days_since_update and review_lag_days - they change daily and
+        # create noise in every diff. They're still in the snapshot for reading.
+        for field in ["status", "promotion_phase", "urgency", "sentiment", "owner",
+                       "target_release"]:
+            old_val = pv.get(field)
+            new_val = cv.get(field)
+            if old_val != new_val:
+                changes.append(f"{vep_id}: {field} {old_val} -> {new_val}")
+
+        # Merge probability
+        old_mp = pv.get("merge_probability")
+        new_mp = cv.get("merge_probability")
+        if old_mp != new_mp:
+            changes.append(f"{vep_id}: merge_probability {old_mp} -> {new_mp}")
+            # Anomaly: large change between two numeric values
+            if old_mp is not None and new_mp is not None:
+                try:
+                    if abs(int(new_mp) - int(old_mp)) > _MERGE_PROB_ANOMALY_THRESHOLD:
+                        anomalies.append(
+                            f"{vep_id}: merge probability changed by "
+                            f">{_MERGE_PROB_ANOMALY_THRESHOLD}pp ({old_mp} -> {new_mp})"
+                        )
+                except (ValueError, TypeError):
+                    pass
+
+        # Compliance sub-fields
+        old_comp = pv.get("compliance", {})
+        new_comp = cv.get("compliance", {})
+        for key in _COMPLIANCE_FIELDS:
+            comp_key = key.replace("-", "_")
+            old_v = old_comp.get(comp_key)
+            new_v = new_comp.get(comp_key)
+            if old_v != new_v:
+                changes.append(f"{vep_id}: compliance.{comp_key} {old_v} -> {new_v}")
+                if old_v is True and new_v is False:
+                    anomalies.append(f"{vep_id}: compliance regressed: {comp_key} true -> false")
+
+        # PR diffs
+        _diff_pr_list(pv, cv, "proposal_prs", "proposal-pr", vep_id, changes)
+        _diff_pr_list(pv, cv, "impl_prs", "impl-pr", vep_id, changes, anomalies)
+
+        # Alert diffs
+        _diff_alert_list(pv, cv, vep_id, changes)
+
+    return changes, anomalies
+
+
+def _diff_pr_list(
+    prev_vep: Dict, curr_vep: Dict, field: str, label: str, vep_id: str,
+    changes: List[str], anomalies: Optional[List[str]] = None,
+) -> None:
+    """Diff PR lists by number, report added/removed/state-changed."""
+    old_prs = {p["number"]: p["state"] for p in prev_vep.get(field, [])}
+    new_prs = {p["number"]: p["state"] for p in curr_vep.get(field, [])}
+
+    for num in sorted(set(new_prs) - set(old_prs)):
+        changes.append(f"{vep_id}: {label} #{num} added ({new_prs[num]})")
+
+    for num in sorted(set(old_prs) - set(new_prs)):
+        changes.append(f"{vep_id}: {label} #{num} removed")
+
+    for num in sorted(set(old_prs) & set(new_prs)):
+        if old_prs[num] != new_prs[num]:
+            changes.append(f"{vep_id}: {label} #{num} {old_prs[num]} -> {new_prs[num]}")
+
+    # Anomaly: PR count decreased (only for impl_prs)
+    if anomalies is not None and len(new_prs) < len(old_prs):
+        anomalies.append(
+            f"{vep_id}: {label} count decreased {len(old_prs)} -> {len(new_prs)} "
+            f"(PRs should not vanish)"
+        )
+
+
+def _diff_alert_list(
+    prev_vep: Dict, curr_vep: Dict, vep_id: str, changes: List[str]
+) -> None:
+    """Diff alert lists by (severity, subject)."""
+    old_keys = {(a["severity"], a["subject"]) for a in prev_vep.get("alerts", [])}
+    new_keys = {(a["severity"], a["subject"]) for a in curr_vep.get("alerts", [])}
+
+    for sev, subj in sorted(new_keys - old_keys):
+        changes.append(f"{vep_id}: new alert [{sev}] {subj}")
+
+    for sev, subj in sorted(old_keys - new_keys):
+        changes.append(f"{vep_id}: resolved alert [{sev}] {subj}")

--- a/nodes/update_sheets.py
+++ b/nodes/update_sheets.py
@@ -51,11 +51,15 @@ def update_sheets_node(state: VEPState) -> Any:
         next_tasks = state.get("next_tasks", [])
         if next_tasks and next_tasks[0] == "update_sheets":
             next_tasks = next_tasks[1:]
-        return {
+        result = {
             "last_check_times": last_check_times,
             "sheets_need_update": False,
             "next_tasks": next_tasks,
         }
+        # In one-cycle mode, signal exit even when sheets are skipped
+        if state.get("one_cycle", False):
+            result["_exit_after_sheets"] = True
+        return result
     
     # Log sheet URL if already configured
     existing_sheet_id = sheet_config.get("sheet_id")

--- a/nodes/wait.py
+++ b/nodes/wait.py
@@ -20,19 +20,6 @@ def wait_node(state: VEPState) -> Any:
     Otherwise, waits until next round hour.
     After waiting, returns to scheduler which will check what needs to run.
     """
-    # In one-cycle mode or test-sheets debug mode, if sheet update completed, exit immediately
-    import os
-    debug_mode = os.environ.get("DEBUG_MODE")
-    should_exit = (
-        (state.get("one_cycle", False) or debug_mode == "test-sheets") and 
-        state.get("_exit_after_sheets", False)
-    )
-    if should_exit:
-        mode_name = "test-sheets debug mode" if debug_mode == "test-sheets" else "one-cycle mode"
-        log(f"{mode_name}: Exiting immediately after sheet update (skipping wait)", node="wait")
-        import sys
-        sys.exit(0)
-    
     now = datetime.now()
     immediate_start = state.get("immediate_start", False)
     

--- a/scripts/run-latest-agent.sh
+++ b/scripts/run-latest-agent.sh
@@ -57,6 +57,7 @@ podman run --rm --pull=newer \
     --network=host \
     -v "$PROJECT_ROOT:/workspace:ro" \
     -v "$PROJECT_ROOT/cache:/workspace/cache:rw" \
+    -v "$PROJECT_ROOT/output:/workspace/output:rw" \
     -w /workspace \
     quay.io/mabekitzur/vep-police-agent:latest \
     "${CMD_ARGS[@]}"

--- a/scripts/run-one-cycle.sh
+++ b/scripts/run-one-cycle.sh
@@ -71,6 +71,7 @@ podman run --rm --pull=newer \
     -e PYTHONUNBUFFERED=1 \
     -v "$PROJECT_ROOT:/workspace:ro" \
     -v "$PROJECT_ROOT/cache:/workspace/cache:rw" \
+    -v "$PROJECT_ROOT/output:/workspace/output:rw" \
     -w /workspace \
     quay.io/mabekitzur/vep-police-agent:latest \
     "${CMD_ARGS[@]}"


### PR DESCRIPTION
## Summary

Each agent cycle now produces a deterministic YAML snapshot of all VEP statuses (`output/vep_snapshot_YYYYMMDD_HHMM.yaml`). Instead of auditing the full agent run, you can just diff two snapshots to see exactly what changed - which VEPs shifted status, which PRs were added, which compliance checks flipped.

Snapshots are timestamped and the last 10 are retained. A companion `output/realizations.txt` auto-diffs the two most recent snapshots and flags anomalies (disappeared VEPs, PR count drops, compliance regressions, large merge probability swings) - no LLM involved, purely deterministic.

Example for vep_snapshot.yaml: [pastebin.com/HJJcPMUy](pastebin.com/HJJcPMUy).
Example for realizations.txt: [pastebin.com/eMKtkAUp](pastebin.com/HJJcPMUy).

Also fixes a bug where `--one-cycle --skip-sheets` would hang forever instead of exiting, because the exit mechanism relied on a flag that was never set when sheets were skipped.

## Test plan

- [x] `ruff check .` passes
- [x] Import smoke test passes
- [x] Full agent cycle (69 VEPs analyzed, snapshot generated correctly)
- [x] `--use-state-cache` quick validation confirms one-cycle exit + snapshot generation

## Commits

1. **Add diff-based testing via deterministic status snapshots** - new `nodes/snapshot.py`, `main.py` integration, README docs
2. **Fix --one-cycle --skip-sheets hanging instead of exiting** - route to LangGraph `END` instead of `sys.exit(0)` in the wait node