### PR TITLE
Track VEP approvers/reviewers and CC into implementation PRs

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -52,3 +52,7 @@ FETCH_VEPS_INTERVAL_SECONDS: int = 4 * 60 * 60  # 4 hours
 LLM_MAX_RETRIES: int = 3
 LLM_INITIAL_DELAY: int = 2  # seconds
 LLM_MAX_TIMEOUT: int = 180  # seconds - abort if exceeded
+
+# CC reviewers configuration
+# Minimum days between CC comments on the same implementation PR
+CC_REVIEWERS_COOLDOWN_DAYS: int = 7

--- a/graph.py
+++ b/graph.py
@@ -23,6 +23,7 @@ from nodes.send_notifications import send_notifications_node
 from nodes.send_email import send_email_node
 from nodes.send_slack import send_slack_node
 from nodes.update_project_board import update_project_board_node
+from nodes.cc_reviewers import cc_reviewers_node
 from nodes.wait import wait_node
 
 def create_graph() -> CompiledStateGraph[Any, Any, Any, Any]:
@@ -65,6 +66,7 @@ def create_graph() -> CompiledStateGraph[Any, Any, Any, Any]:
     workflow.add_node("send_email", send_email_node)
     workflow.add_node("send_slack", send_slack_node)
     workflow.add_node("update_project_board", update_project_board_node)
+    workflow.add_node("cc_reviewers", cc_reviewers_node)
     workflow.add_node("wait", wait_node)
     
     # Set entry point
@@ -81,6 +83,7 @@ def create_graph() -> CompiledStateGraph[Any, Any, Any, Any]:
             "run_monitoring": "run_monitoring",
             "update_sheets": "update_sheets",
             "update_project_board": "update_project_board",
+            "cc_reviewers": "cc_reviewers",
             "alert_summary": "alert_summary",
             "wait": "wait",
         }
@@ -123,9 +126,10 @@ def create_graph() -> CompiledStateGraph[Any, Any, Any, Any]:
     workflow.add_edge("send_notifications", "send_email")
     workflow.add_edge("send_notifications", "send_slack")
 
-    # update_sheets, update_project_board, send_email, and send_slack go back to scheduler
+    # update_sheets, update_project_board, cc_reviewers, send_email, and send_slack go back to scheduler
     workflow.add_edge("update_sheets", "scheduler")
     workflow.add_edge("update_project_board", "scheduler")
+    workflow.add_edge("cc_reviewers", "scheduler")
     workflow.add_edge("send_email", "scheduler")
     workflow.add_edge("send_slack", "scheduler")
     
@@ -138,7 +142,7 @@ def create_graph() -> CompiledStateGraph[Any, Any, Any, Any]:
     return workflow.compile()
 
 
-def route_scheduler_operations(state: VEPState) -> Literal["fetch_veps", "run_monitoring", "update_sheets", "update_project_board", "alert_summary", "wait"]:
+def route_scheduler_operations(state: VEPState) -> Literal["fetch_veps", "run_monitoring", "update_sheets", "update_project_board", "cc_reviewers", "alert_summary", "wait"]:
     """Route based on scheduler's next_tasks.
     
     Routes to the first task in the queue. The scheduler can queue:
@@ -179,7 +183,7 @@ def route_scheduler_operations(state: VEPState) -> Literal["fetch_veps", "run_mo
             return "wait"
     
     # Validate it's a known task, otherwise wait
-    valid_tasks = {"fetch_veps", "run_monitoring", "update_sheets", "update_project_board", "alert_summary", "wait"}
+    valid_tasks = {"fetch_veps", "run_monitoring", "update_sheets", "update_project_board", "cc_reviewers", "alert_summary", "wait"}
     return task if task in valid_tasks else "wait"
 
 

--- a/main.py
+++ b/main.py
@@ -72,7 +72,7 @@ def load_state_cache() -> Optional[Dict[str, Any]]:
         return None
 
 
-def get_initial_state(sheet_id: Optional[str] = None, index_cache_minutes: int = 60, one_cycle: bool = False, skip_monitoring: bool = False, skip_sheets: bool = False, skip_update_board: bool = False, skip_send_email: bool = False, skip_send_slack: bool = False, mock_veps: bool = False, mock_analyzed_combined: bool = False, mock_alert_summary: bool = False, immediate_start: bool = False, use_state_cache: bool = False):
+def get_initial_state(sheet_id: Optional[str] = None, index_cache_minutes: int = 60, one_cycle: bool = False, skip_monitoring: bool = False, skip_sheets: bool = False, skip_update_board: bool = False, skip_send_email: bool = False, skip_send_slack: bool = False, skip_cc_reviewers: bool = False, mock_veps: bool = False, mock_analyzed_combined: bool = False, mock_alert_summary: bool = False, immediate_start: bool = False, use_state_cache: bool = False):
     """Create initial state for the agent."""
     sheet_config = {
         "sheet_name": "VEP Status",  # Optional: name for the sheet/tab
@@ -109,6 +109,7 @@ def get_initial_state(sheet_id: Optional[str] = None, index_cache_minutes: int =
         "skip_update_board": skip_update_board,  # Flag to skip writing to GitHub project board
         "skip_send_email": skip_send_email,  # Flag to skip sending email alerts
         "skip_send_slack": skip_send_slack,  # Flag to skip sending Slack alerts
+        "skip_cc_reviewers": skip_cc_reviewers,  # Flag to skip posting CC comments on impl PRs
         "mock_veps": mock_veps,  # Flag to use mock VEPs instead of fetching from GitHub
         "mock_analyzed_combined": mock_analyzed_combined,  # Flag to skip LLM in analyze_combined
         "mock_alert_summary": mock_alert_summary,  # Flag to skip LLM in alert_summary
@@ -183,6 +184,8 @@ def log_startup_flags(args, index_cache_minutes: int) -> None:
         flags.append("  --skip-send-email: enabled")
     if args.skip_send_slack:
         flags.append("  --skip-send-slack: enabled")
+    if args.skip_cc_reviewers:
+        flags.append("  --skip-cc-reviewers: enabled")
     if args.mock_veps:
         flags.append("  --mock-veps: enabled")
     if args.mock_analyzed_combined:
@@ -212,6 +215,8 @@ def log_startup_flags(args, index_cache_minutes: int) -> None:
         log("Skip-sheets mode: Google Sheets updates will be skipped", node="main")
     if args.skip_update_board:
         log("Skip-update-board mode: GitHub project board updates will be skipped", node="main")
+    if args.skip_cc_reviewers:
+        log("Skip-cc-reviewers mode: CC comments will not be posted on implementation PRs", node="main")
     if args.mock_veps:
         log("Mock VEPs mode: will use mock VEPs instead of fetching from GitHub", node="main")
     if args.mock_analyzed_combined:
@@ -311,6 +316,11 @@ def parse_args():
         "--skip-send-slack",
         action="store_true",
         help="Skip sending Slack alerts. Useful for debugging without sending Slack messages."
+    )
+    parser.add_argument(
+        "--skip-cc-reviewers",
+        action="store_true",
+        help="Skip posting CC comments on implementation PRs. Useful when testing without issue write scope."
     )
     parser.add_argument(
         "--mock-veps",
@@ -481,7 +491,7 @@ def main():
     log("Graph created successfully", node="main")
     
     # Initialize state
-    initial_state = get_initial_state(sheet_id=args.sheet_id, index_cache_minutes=index_cache_minutes, one_cycle=args.one_cycle, skip_monitoring=args.skip_monitoring, skip_sheets=args.skip_sheets, skip_update_board=args.skip_update_board, skip_send_email=args.skip_send_email, skip_send_slack=args.skip_send_slack, mock_veps=args.mock_veps, mock_analyzed_combined=args.mock_analyzed_combined, mock_alert_summary=args.mock_alert_summary, immediate_start=args.immediate_start, use_state_cache=args.use_state_cache)
+    initial_state = get_initial_state(sheet_id=args.sheet_id, index_cache_minutes=index_cache_minutes, one_cycle=args.one_cycle, skip_monitoring=args.skip_monitoring, skip_sheets=args.skip_sheets, skip_update_board=args.skip_update_board, skip_send_email=args.skip_send_email, skip_send_slack=args.skip_send_slack, skip_cc_reviewers=args.skip_cc_reviewers, mock_veps=args.mock_veps, mock_analyzed_combined=args.mock_analyzed_combined, mock_alert_summary=args.mock_alert_summary, immediate_start=args.immediate_start, use_state_cache=args.use_state_cache)
 
     # Load state cache if requested
     if args.use_state_cache:

--- a/nodes/alert_formatting.py
+++ b/nodes/alert_formatting.py
@@ -242,6 +242,9 @@ def build_vep_summary_table(veps: List[Any], indexed_context: Dict[str, Any] = N
             "vep_number": vep.tracking_issue_id,
             "vep_name": vep.name,
             "title": vep.title[:50] if vep.title else "",  # Truncate for readability
+            "owner": vep.owner,
+            "approvers": getattr(vep, "approvers", []),
+            "reviewers": getattr(vep, "reviewers", []),
             "proposal_prs": proposal_prs,
             "impl_prs": impl_prs,
             "urgency": urgency,

--- a/nodes/cc_reviewers.py
+++ b/nodes/cc_reviewers.py
@@ -1,0 +1,114 @@
+"""CC reviewers node - CCs VEP approvers/reviewers into open implementation PRs.
+
+For each VEP with known approvers or reviewers (extracted from enhancement PR
+reviews), checks open implementation PRs for an existing CC comment and, if
+none is found within the cooldown window, posts a comment @-mentioning them
+for visibility.
+
+No LLM involved - pure data checks and GitHub REST API calls.
+"""
+
+from datetime import datetime
+from typing import Any, Dict, List
+
+from state import VEPState
+from services.utils import log
+from services.github_api import (
+    add_issue_comment,
+    has_cc_comment,
+    CC_REVIEWERS_MARKER,
+)
+from config.config import CC_REVIEWERS_COOLDOWN_DAYS
+
+# Repository hosting implementation PRs
+KUBEVIRT_OWNER = "kubevirt"
+KUBEVIRT_REPO = "kubevirt"
+
+
+def _build_cc_comment(vep, people: List[str]) -> str:
+    """Build the Markdown CC comment body for an implementation PR."""
+    mentions = " ".join(f"@{h}" for h in people)
+    lines = [
+        f"This PR implements **{vep.name}** "
+        f"([tracking issue](https://github.com/kubevirt/enhancements/issues/{vep.tracking_issue_id})). "
+        f"CC'ing the VEP approvers and reviewers for visibility:",
+        "",
+        f"cc {mentions}",
+        "",
+        CC_REVIEWERS_MARKER,
+    ]
+    return "\n".join(lines)
+
+
+def cc_reviewers_node(state: VEPState) -> Any:
+    """Post CC comments on open implementation PRs for VEPs with known reviewers.
+
+    Skipped when ``skip_cc_reviewers`` is set in state.
+    """
+    last_check_times: Dict[str, datetime] = state.get("last_check_times", {})
+
+    if state.get("skip_cc_reviewers", False):
+        log("skip_cc_reviewers enabled, skipping", node="cc_reviewers")
+        last_check_times["cc_reviewers"] = datetime.now()
+        return {"last_check_times": last_check_times}
+
+    veps = state.get("veps", [])
+    if not veps:
+        log("No VEPs to check for CC", node="cc_reviewers")
+        last_check_times["cc_reviewers"] = datetime.now()
+        return {"last_check_times": last_check_times}
+
+    # Collect VEPs that have people to CC and open impl PRs
+    candidates = []
+    for vep in veps:
+        people = sorted(set(getattr(vep, "approvers", []) + getattr(vep, "reviewers", [])))
+        if not people:
+            continue
+        # Exclude the VEP owner from the CC list — they already know about the PR
+        owner = getattr(vep, "owner", "")
+        people = [p for p in people if p != owner]
+        if not people:
+            continue
+
+        open_impl_prs = [
+            pr for pr in getattr(vep, "implementation_prs", [])
+            if pr.state == "open"
+        ]
+        if open_impl_prs:
+            candidates.append((vep, people, open_impl_prs))
+
+    log(f"{len(candidates)}/{len(veps)} VEP(s) have reviewers and open impl PRs",
+        node="cc_reviewers")
+
+    commented = 0
+    skipped_cooldown = 0
+
+    for vep, people, open_prs in candidates:
+        for pr in open_prs:
+            pr_number = pr.number
+            if has_cc_comment(
+                KUBEVIRT_OWNER,
+                KUBEVIRT_REPO,
+                pr_number,
+                cooldown_days=CC_REVIEWERS_COOLDOWN_DAYS,
+            ):
+                log(f"VEP {vep.name} PR #{pr_number}: recent CC exists, skipping",
+                    node="cc_reviewers", level="DEBUG")
+                skipped_cooldown += 1
+                continue
+
+            comment_body = _build_cc_comment(vep, people)
+            result = add_issue_comment(
+                KUBEVIRT_OWNER, KUBEVIRT_REPO, pr_number, comment_body,
+            )
+            if result:
+                commented += 1
+                log(f"VEP {vep.name} PR #{pr_number}: CC'd {len(people)} reviewer(s)",
+                    node="cc_reviewers")
+
+    log(f"CC complete: {commented} PR(s) commented, "
+        f"{skipped_cooldown} skipped (cooldown)",
+        node="cc_reviewers")
+
+    last_check_times["cc_reviewers"] = datetime.now()
+    return {"last_check_times": last_check_times}

--- a/nodes/fetch_veps.py
+++ b/nodes/fetch_veps.py
@@ -261,6 +261,7 @@ def fetch_veps_node(state: VEPState) -> Any:
     board_veps = indexed_context.get("board_veps", {})  # Dict[issue_number -> board_data]
     issues_index = indexed_context.get("issues_index", [])
     vep_files_index = indexed_context.get("vep_files_index", [])
+    enhancement_pr_reviews = indexed_context.get("enhancement_pr_reviews", {})  # Dict[issue_number -> {approvers, reviewers}]
 
     # Build lookups
     issues_by_number = {issue.get("number"): issue for issue in issues_index if issue.get("number")}
@@ -391,6 +392,13 @@ def fetch_veps_node(state: VEPState) -> Any:
                 total_count = len(vep_info.implementation_prs)
                 if merged_count > 0:
                     log(f"  VEP #{issue_number} ({vep_info.name}): {merged_count}/{total_count} impl PRs merged", node="fetch_veps", level="DEBUG")
+
+            # Populate approvers/reviewers from enhancement PR review data
+            # Keys may be int (in-memory) or str (after JSON cache round-trip)
+            review_data = enhancement_pr_reviews.get(issue_number) or enhancement_pr_reviews.get(str(issue_number)) or {}
+            if review_data:
+                vep_info.approvers = review_data.get("approvers", [])
+                vep_info.reviewers = review_data.get("reviewers", [])
 
             discovered_veps.append(vep_info)
 

--- a/nodes/scheduler.py
+++ b/nodes/scheduler.py
@@ -135,6 +135,8 @@ def scheduler_node(state: VEPState) -> Any:
                 next_tasks.append("update_sheets")
             if not state.get("skip_update_board", False):
                 next_tasks.append("update_project_board")
+            if not state.get("skip_cc_reviewers", False):
+                next_tasks.append("cc_reviewers")
             next_tasks.append("alert_summary")
             # Set last_check_times for fetch_veps so the interval check doesn't
             # immediately schedule fetch_veps on the next scheduler call
@@ -162,11 +164,13 @@ def scheduler_node(state: VEPState) -> Any:
                 next_tasks.append("run_monitoring")
             else:
                 log("First run: Skip-monitoring enabled, skipping analysis pipeline", node="scheduler")
-        # Schedule update_sheets, update_project_board, and alert_summary after analysis
-        log("First run: Scheduling update_sheets, update_project_board, and alert_summary", node="scheduler")
+        # Schedule update_sheets, update_project_board, cc_reviewers, and alert_summary after analysis
+        log("First run: Scheduling update_sheets, update_project_board, cc_reviewers, and alert_summary", node="scheduler")
         next_tasks.append("update_sheets")
         if not state.get("skip_update_board", False):
             next_tasks.append("update_project_board")
+        if not state.get("skip_cc_reviewers", False):
+            next_tasks.append("cc_reviewers")
         next_tasks.append("alert_summary")
     else:
         # If immediate_start is enabled, don't check for round hour - use interval-based timing
@@ -238,6 +242,13 @@ def scheduler_node(state: VEPState) -> Any:
             if update_board_time is None or update_board_time < analyze_combined_time:
                 log("analyze_combined completed, scheduling update_project_board", node="scheduler")
                 next_tasks.append("update_project_board")
+
+        # Schedule cc_reviewers if it hasn't run since analyze_combined
+        cc_reviewers_time = last_check_times.get("cc_reviewers")
+        if "cc_reviewers" not in next_tasks and not state.get("skip_cc_reviewers", False):
+            if cc_reviewers_time is None or cc_reviewers_time < analyze_combined_time:
+                log("analyze_combined completed, scheduling cc_reviewers", node="scheduler")
+                next_tasks.append("cc_reviewers")
 
         # Schedule alert_summary if it hasn't run since analyze_combined
         if "alert_summary" not in next_tasks:

--- a/nodes/update_project_board.py
+++ b/nodes/update_project_board.py
@@ -98,6 +98,7 @@ def update_project_board_node(state: VEPState) -> Any:
 
     # Verify the expected fields exist on the board
     expected_fields = ["Agent Urgency", "Agent Comment", "Proposal PRs", "Impl PRs"]
+    # "VEP approver"/"VEP reviewer" are optional — only written when present on the board
     missing = [f for f in expected_fields if f not in fields_meta]
     if missing:
         log(f"Missing expected fields on project board: {missing}. "
@@ -134,6 +135,14 @@ def update_project_board_node(state: VEPState) -> Any:
             "Proposal PRs": format_pr_links_plain(row.get("proposal_prs", [])),
             "Impl PRs": format_pr_links_plain(row.get("impl_prs", [])),
         }
+
+        # Write VEP approver/reviewer when the fields exist on the board
+        if "VEP approver" in fields_meta:
+            approvers = row.get("approvers", [])
+            field_updates["VEP approver"] = ", ".join(f"@{u}" for u in approvers) if approvers else ""
+        if "VEP reviewer" in fields_meta:
+            reviewers = row.get("reviewers", [])
+            field_updates["VEP reviewer"] = ", ".join(f"@{u}" for u in reviewers) if reviewers else ""
 
         count = update_project_item_fields(project_id, item_id, field_updates, fields_meta)
         if count > 0:

--- a/services/github_api.py
+++ b/services/github_api.py
@@ -1,0 +1,161 @@
+"""GitHub REST API helpers for write operations and review data.
+
+Provides thin wrappers around the GitHub REST API for controlled write
+operations (e.g. posting issue comments) and fetching PR review data.
+These bypass the read-only MCP layer so that LLM-driven nodes stay
+read-only while deterministic pipeline nodes can perform targeted writes.
+"""
+
+import os
+from typing import Any, Dict, List, Optional
+
+import requests
+
+from services.utils import log
+
+API_BASE = "https://api.github.com"
+
+# Marker embedded in CC comments posted by the agent so we can detect prior CCs.
+CC_REVIEWERS_MARKER = "<!-- vep-police-agent:cc-reviewers -->"
+
+
+def _headers() -> Dict[str, str]:
+    token = os.environ.get("GITHUB_TOKEN")
+    if not token:
+        raise RuntimeError("GITHUB_TOKEN environment variable not set")
+    return {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+
+def add_issue_comment(owner: str, repo: str, issue_number: int, body: str) -> Optional[Dict[str, Any]]:
+    """Post a comment on a GitHub issue or pull request.
+
+    Args:
+        owner: Repository owner (e.g. "kubevirt")
+        repo: Repository name (e.g. "kubevirt")
+        issue_number: Issue or PR number
+        body: Markdown comment body
+
+    Returns:
+        Parsed JSON response on success, None on failure
+    """
+    url = f"{API_BASE}/repos/{owner}/{repo}/issues/{issue_number}/comments"
+    try:
+        resp = requests.post(url, json={"body": body}, headers=_headers(), timeout=30)
+        resp.raise_for_status()
+        log(f"Posted comment on {owner}/{repo}#{issue_number}", node="github_api")
+        return resp.json()
+    except requests.RequestException as e:
+        log(f"Failed to post comment on {owner}/{repo}#{issue_number}: {e}",
+            node="github_api", level="ERROR")
+        return None
+
+
+def get_issue_comments(owner: str, repo: str, issue_number: int) -> List[Dict[str, Any]]:
+    """Fetch all comments on a GitHub issue or pull request.
+
+    Args:
+        owner: Repository owner
+        repo: Repository name
+        issue_number: Issue or PR number
+
+    Returns:
+        List of comment dicts (may be empty on error)
+    """
+    comments: List[Dict[str, Any]] = []
+    url = f"{API_BASE}/repos/{owner}/{repo}/issues/{issue_number}/comments"
+    params: Dict[str, Any] = {"per_page": 100, "page": 1}
+
+    try:
+        while True:
+            resp = requests.get(url, params=params, headers=_headers(), timeout=30)
+            resp.raise_for_status()
+            page = resp.json()
+            if not page:
+                break
+            comments.extend(page)
+            if len(page) < 100:
+                break
+            params["page"] += 1
+    except requests.RequestException as e:
+        log(f"Failed to fetch comments for {owner}/{repo}#{issue_number}: {e}",
+            node="github_api", level="ERROR")
+
+    return comments
+
+
+def get_pull_request_reviews(owner: str, repo: str, pull_number: int) -> List[Dict[str, Any]]:
+    """Fetch all reviews on a pull request.
+
+    Args:
+        owner: Repository owner
+        repo: Repository name
+        pull_number: PR number
+
+    Returns:
+        List of review dicts, each containing at least ``user.login`` and ``state``
+        (APPROVED, CHANGES_REQUESTED, COMMENTED, DISMISSED).
+    """
+    reviews: List[Dict[str, Any]] = []
+    url = f"{API_BASE}/repos/{owner}/{repo}/pulls/{pull_number}/reviews"
+    params: Dict[str, Any] = {"per_page": 100, "page": 1}
+
+    try:
+        while True:
+            resp = requests.get(url, params=params, headers=_headers(), timeout=30)
+            resp.raise_for_status()
+            page = resp.json()
+            if not page:
+                break
+            reviews.extend(page)
+            if len(page) < 100:
+                break
+            params["page"] += 1
+    except requests.RequestException as e:
+        log(f"Failed to fetch reviews for {owner}/{repo}#{pull_number}: {e}",
+            node="github_api", level="ERROR")
+
+    return reviews
+
+
+def has_cc_comment(owner: str, repo: str, issue_number: int,
+                   cooldown_days: int = 7) -> bool:
+    """Check whether a CC-reviewers comment was already posted recently.
+
+    Looks for the ``CC_REVIEWERS_MARKER`` HTML comment in issue/PR comments.
+    If the most recent CC is older than *cooldown_days*, returns False so
+    a fresh CC can be sent.
+
+    Args:
+        owner: Repository owner
+        repo: Repository name
+        issue_number: Issue or PR number
+        cooldown_days: Minimum days between CC comments
+
+    Returns:
+        True if a recent CC exists (skip posting), False otherwise
+    """
+    from datetime import datetime, timezone, timedelta
+
+    comments = get_issue_comments(owner, repo, issue_number)
+    cutoff = datetime.now(timezone.utc) - timedelta(days=cooldown_days)
+
+    for comment in reversed(comments):  # newest first
+        body = comment.get("body", "")
+        if CC_REVIEWERS_MARKER not in body:
+            continue
+        created = comment.get("created_at", "")
+        try:
+            created_dt = datetime.fromisoformat(created.replace("Z", "+00:00"))
+        except (ValueError, AttributeError):
+            # Can't parse date -- treat as recent to be safe
+            return True
+        if created_dt >= cutoff:
+            return True
+        # Found the marker but it's older than cooldown -- allow re-CC
+        return False
+
+    return False

--- a/services/indexer.py
+++ b/services/indexer.py
@@ -2180,6 +2180,71 @@ def index_approved_vep_prs(prs_index: Optional[List[Dict[str, Any]]] = None) -> 
     return approved_vep_prs
 
 
+def index_enhancement_pr_reviews(
+    enhancements_prs: Optional[List[Dict[str, Any]]] = None,
+) -> Dict[int, Dict[str, List[str]]]:
+    """Fetch reviews for enhancement PRs and group by VEP tracking issue.
+
+    For each enhancement PR that is linked to a VEP tracking issue, fetches
+    the PR reviews from the GitHub REST API and classifies reviewers as
+    approvers (state=APPROVED) or reviewers (any review submitted).
+
+    Args:
+        enhancements_prs: Pre-fetched list from ``index_enhancements_prs()``.
+            If None, will be fetched.
+
+    Returns:
+        Dict mapping *VEP tracking issue number* -> {"approvers": [...], "reviewers": [...]}.
+        Usernames are deduplicated. The VEP owner is excluded from both lists.
+    """
+    from services.github_api import get_pull_request_reviews
+
+    if enhancements_prs is None:
+        enhancements_prs = index_enhancements_prs(days_back=None)
+
+    log(f"Fetching reviews for {len(enhancements_prs)} enhancement PRs", node="indexer")
+
+    # Group enhancement PRs by VEP tracking issue
+    prs_by_vep: Dict[int, List[Dict[str, Any]]] = {}
+    for pr in enhancements_prs:
+        vep_issue = pr.get("vep_issue_number")
+        if vep_issue:
+            prs_by_vep.setdefault(vep_issue, []).append(pr)
+
+    result: Dict[int, Dict[str, List[str]]] = {}
+
+    for vep_issue, prs in prs_by_vep.items():
+        approvers_set: set[str] = set()
+        reviewers_set: set[str] = set()
+
+        for pr in prs:
+            pr_number = pr.get("number")
+            if not pr_number:
+                continue
+
+            reviews = get_pull_request_reviews("kubevirt", "enhancements", pr_number)
+            for review in reviews:
+                user = review.get("user", {})
+                login = user.get("login", "") if isinstance(user, dict) else ""
+                if not login:
+                    continue
+                state = review.get("state", "")
+                reviewers_set.add(login)
+                if state == "APPROVED":
+                    approvers_set.add(login)
+            time.sleep(API_DELAY)
+
+        result[vep_issue] = {
+            "approvers": sorted(approvers_set),
+            "reviewers": sorted(reviewers_set),
+        }
+
+    reviewed_count = sum(1 for v in result.values() if v["reviewers"])
+    log(f"Indexed reviews for {len(result)} VEPs ({reviewed_count} have reviewers)", node="indexer")
+
+    return result
+
+
 def _load_cached_index(cache_file: Path, max_age_minutes: int = 60) -> Optional[Dict[str, Any]]:
     """Load cached indexed context if it exists and is fresh.
     
@@ -2549,6 +2614,9 @@ def create_indexed_context(days_back: Optional[int] = 365, cache_max_age_minutes
     project_board_items = index_project_board_items(version=release_version)
     vep_to_pr_mappings = index_vep_pr_mappings(prs_index=prs_index)
 
+    # Fetch reviews for enhancement PRs (approvers/reviewers per VEP)
+    enhancement_pr_reviews = index_enhancement_pr_reviews(enhancements_prs=enhancements_prs)
+
     indexed_context = {
         "release_info": release_info,
         "current_release": release_version,
@@ -2565,6 +2633,8 @@ def create_indexed_context(days_back: Optional[int] = 365, cache_max_age_minutes
         "approved_vep_prs": index_approved_vep_prs(prs_index=prs_index),
         # VEPs that are tracked but have no implementation PRs
         "veps_missing_prs": compute_veps_missing_prs(project_board_items, vep_to_pr_mappings),
+        # Approvers/reviewers extracted from enhancement PR reviews
+        "enhancement_pr_reviews": enhancement_pr_reviews,
         "indexed_at": datetime.now().isoformat(),
         "days_back": days_back,
     }

--- a/state.py
+++ b/state.py
@@ -171,6 +171,10 @@ class VEPInfo(BaseModel):
     compliance: VEPCompliance  # Compliance check results
     activity: VEPActivity  # Activity metrics for monitoring
 
+    # People associated with the VEP (extracted from enhancement PR reviews)
+    approvers: List[str] = []  # GitHub usernames who approved the VEP enhancement PR(s)
+    reviewers: List[str] = []  # GitHub usernames who reviewed the VEP enhancement PR(s)
+
     # Related GitHub resources
     tracking_issue: IssueInfo | None  # Full tracking issue data from GitHub
     enhancement_prs: List[PRInfo] = []  # PRs in kubevirt/enhancements repo (VEP creation/updates)
@@ -239,3 +243,4 @@ class VEPState(TypedDict):
     use_state_cache: bool  # Flag to use cached state from previous run on first cycle
     _state_cache_used: bool  # Internal flag tracking if state cache was used this run
     _force_sheets_update: bool  # Internal flag to force sheets update on first cache cycle
+    skip_cc_reviewers: bool  # Flag to skip posting CC comments on implementation PRs


### PR DESCRIPTION
Closes #17

## Summary

- Adds `approvers` and `reviewers` fields to `VEPInfo`, populated from enhancement PR reviews via the GitHub REST API during indexing
- Writes `VEP approver` and `VEP reviewer` text fields to the project board (these fields already exist on the [v1.9 tracking board](https://github.com/orgs/kubevirt/projects/21); gracefully skipped if absent)
- New `cc_reviewers` pipeline node that CCs VEP approvers/reviewers into open implementation PRs via a comment, with debounce (7-day cooldown via HTML comment marker)
- `services/github_api.py` provides REST API helpers for comments and PR review fetching, keeping MCP read-only for LLM-driven nodes
- Gated behind `--skip-cc-reviewers` CLI flag

## Files changed

| File | Change |
|------|--------|
| `state.py` | Add `approvers`, `reviewers` to `VEPInfo`; add `skip_cc_reviewers` flag |
| `services/github_api.py` | **New** — REST API helpers (comments, PR reviews, debounce) |
| `services/indexer.py` | Add `index_enhancement_pr_reviews()`, include in indexed context |
| `nodes/fetch_veps.py` | Populate `approvers`/`reviewers` from indexed review data |
| `nodes/alert_formatting.py` | Include owner/approvers/reviewers in summary table rows |
| `nodes/update_project_board.py` | Write `VEP approver`/`VEP reviewer` fields (when present on board) |
| `nodes/cc_reviewers.py` | **New** — CC approvers/reviewers into open impl PRs |
| `config/config.py` | Add `CC_REVIEWERS_COOLDOWN_DAYS` |
| `graph.py` | Add `cc_reviewers` node and edges |
| `nodes/scheduler.py` | Schedule `cc_reviewers` after analysis |
| `main.py` | Add `--skip-cc-reviewers` CLI flag |

## Remaining work

- [ ] Verify the `GITHUB_TOKEN` has `issues:write` scope for posting CC comments

## Test plan

- [ ] Run with `--skip-cc-reviewers` and verify the node is skipped
- [ ] Run a full cycle and verify `VEPInfo.approvers`/`reviewers` are populated from enhancement PR reviews
- [ ] Verify `VEP approver`/`VEP reviewer` fields are written to the board (or gracefully skipped when absent)
- [ ] Verify CC comments appear on open implementation PRs with the correct @-mentions
- [ ] Run again within cooldown and verify no duplicate CC comments are posted