### PR TITLE
Add release-aware PR classification to VEP completeness assessment

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ graph TD
 2. `fetch_veps` discovers VEPs from GitHub and returns to scheduler.
 3. Scheduler routes to `run_monitoring`, which fans out to five parallel check nodes (deadlines, activity, compliance, exceptions, phase risks) using Flash model.
 4. `merge_vep_updates` combines context data (deterministic, no LLM).
-5. `analyze_combined` (Pro model) does cross-domain reasoning and generates alerts.
+5. `analyze_combined` (Pro model) does cross-domain reasoning and generates alerts. Uses the previous release's code freeze date to distinguish current-release vs previous-release PRs - VEPs with only old PRs are flagged instead of shown as complete.
 6. `detect_changes` compares to previous run for accurate change reporting.
 7. `update_sheets`, `update_project_board`, and `alert_summary` run on schedule; alerts fan out to email and Slack.
 

--- a/nodes/analyze_combined.py
+++ b/nodes/analyze_combined.py
@@ -5,14 +5,68 @@ This node has access to ALL context at once and does holistic reasoning.
 """
 
 import json
-from datetime import datetime
-from typing import Any, List
-from state import VEPState
+from datetime import datetime, date, time, timedelta, timezone
+from typing import Any, List, Optional, Tuple
+from state import VEPState, PRInfo
 from services.utils import log
 from services.llm_helper import invoke_llm_check
 from services.response_models import CheckResponse
 from services.indexer import create_indexed_context
 from nodes.alert_formatting import build_vep_summary_table, build_markdown_table
+
+
+def classify_prs_by_release(impl_prs: List[PRInfo], cutoff: datetime) -> Tuple[List[PRInfo], List[PRInfo]]:
+    """Classify implementation PRs as current-release vs previous-release work.
+
+    The cutoff is the previous release's code freeze date (when its branch was
+    cut from main). PRs merged to main before that date belong to the previous
+    release; PRs merged after or still open belong to the current release.
+
+    Returns (current_release_prs, previous_release_prs).
+    Closed-not-merged (abandoned) PRs are excluded from both lists.
+    Unknown-state PRs are treated as current-release (conservative) to prevent
+    false 10% assignments when PR data is incomplete.
+    """
+    current, previous = [], []
+    for pr in impl_prs:
+        if pr.state == "open":
+            current.append(pr)
+        elif pr.state == "merged" and pr.merged_at:
+            if pr.merged_at > cutoff:
+                current.append(pr)
+            else:
+                previous.append(pr)
+        elif pr.state == "merged":
+            # merged_at not available - can't classify, treat as current (conservative)
+            current.append(pr)
+        elif pr.state == "closed":
+            pass  # closed-not-merged (abandoned): excluded from both lists
+        else:
+            # unknown or unrecognized state: treat as current (conservative)
+            current.append(pr)
+    return current, previous
+
+
+def _build_previous_release_override(
+    num_previous_prs: int, cutoff_str: str, phase_info: str, old_prob: Optional[int] = None
+) -> dict:
+    """Build risk assessment dict for VEPs with only previous-release PRs."""
+    reasoning = (
+        f"All {num_previous_prs} implementation PRs merged before previous release "
+        f"code freeze ({cutoff_str}), no current-release activity. "
+        f"Promotion phase: {phase_info}."
+    )
+    if old_prob is not None:
+        reasoning += f" (LLM estimated {old_prob}%)"
+    return {
+        "merge_probability": 10,
+        "reviewer_sentiment": "concerned",
+        "recent_progress": False,
+        "days_inactive": 0,  # no current-release PRs to measure staleness on
+        "reasoning": reasoning,
+        "recommend_escalation": True,
+        "escalation_actions": ["Open implementation PRs for current release"],
+    }
 
 
 class AnalyzeCombinedResponse(CheckResponse):
@@ -150,6 +204,22 @@ def analyze_combined_node(state: VEPState) -> Any:
     release_phase = indexed_context.get("release_phase", "unknown")
     release_deadlines = indexed_context.get("release_deadlines", {})
     board_veps = indexed_context.get("board_veps", {})
+
+    # Parse previous release code freeze cutoff for release-aware PR classification
+    prev_cf_str = indexed_context.get("previous_release_code_freeze")
+    release_cutoff: Optional[datetime] = None
+    if prev_cf_str:
+        try:
+            # Add 7-day buffer after the scheduled code freeze to account for
+            # the community delaying the actual branch cut by up to a week
+            release_cutoff = datetime.combine(
+                date.fromisoformat(prev_cf_str), time.min, tzinfo=timezone.utc
+            ) + timedelta(days=7)
+            log(f"Release cutoff for PR classification: {prev_cf_str} + 7d buffer = {release_cutoff.date().isoformat()}", node="analyze_combined")
+        except (ValueError, TypeError):
+            log(f"Could not parse previous_release_code_freeze: {prev_cf_str}", node="analyze_combined", level="WARNING")
+    else:
+        log("Release-aware PR classification disabled: no previous release code freeze date available", node="analyze_combined", level="WARNING")
 
     # Extract phase_risks from VEPs for focused analysis
     phase_risks = []
@@ -438,7 +508,12 @@ For EVERY VEP (skip any with "_deterministic_risk" in analysis):
 8. Recommend escalation if probability < 50% OR blocked OR no recent_progress
 9. Store in vep.analysis["risk_assessment"] with recent_progress and days_inactive fields
 
-For VEPs where ALL implementation PRs are merged:
+RELEASE-AWARENESS: PRs merged before the previous release's code freeze ({prev_cf_str or 'unknown'})
+are PREVIOUS-RELEASE work, not current-release progress. Ignore previous-release PRs when assessing
+completeness - only current-release PRs matter. A VEP with no current-release PRs should have LOW
+probability (around 10%), regardless of how many previous-release PRs were merged.
+
+For VEPs where ALL CURRENT-RELEASE implementation PRs are merged:
 - If the VEP proposal is also merged OR we are past the relevant freeze: set merge_probability to 100%
 - Otherwise: set merge_probability to 95%
 - Set reviewer_sentiment to "positive"
@@ -526,14 +601,27 @@ Return updated VEPs with complete analysis, general_insights list, and sheets_ne
                 vep.analysis = {}
             fallback_count += 1
 
-            # Check if all implementation PRs are merged
+            # Determine effective PRs: filter to current-release only when cutoff available
             all_merged = False
             has_impl_prs = bool(vep.implementation_prs)
+            effective_prs = vep.implementation_prs
+            if has_impl_prs and release_cutoff:
+                current_prs, previous_prs = classify_prs_by_release(vep.implementation_prs, release_cutoff)
+                if previous_prs and not current_prs:
+                    phase_info = getattr(vep.current_milestone, 'promotion_phase', 'Net New')
+                    vep.analysis["risk_assessment"] = _build_previous_release_override(
+                        len(previous_prs), prev_cf_str or "unknown", phase_info
+                    )
+                    log(f"Fallback: {vep.name} has only previous-release PRs ({len(previous_prs)}), prob=10%", node="analyze_combined")
+                    continue
+                elif current_prs:
+                    effective_prs = current_prs
+
             if has_impl_prs:
                 # Consider PRs as done if merged, closed, or unknown (unknown = too old to fetch, likely merged)
-                all_merged = all(pr.state in ("merged", "closed", "unknown") for pr in vep.implementation_prs)
+                all_merged = all(pr.state in ("merged", "closed", "unknown") for pr in effective_prs)
                 # But require at least one PR with confirmed merged/closed state
-                any_confirmed = any(pr.state in ("merged", "closed") for pr in vep.implementation_prs)
+                any_confirmed = any(pr.state in ("merged", "closed") for pr in effective_prs)
                 all_merged = all_merged and any_confirmed
 
             if all_merged and has_impl_prs:
@@ -555,8 +643,8 @@ Return updated VEPs with complete analysis, general_insights list, and sheets_ne
                 # Open impl PRs are normal and expected — focus on proposal progress.
                 vep.analysis["risk_assessment"] = _fallback_design_phase(vep)
             elif has_impl_prs:
-                merged_count = sum(1 for pr in vep.implementation_prs if pr.state == "merged")
-                total_count = len(vep.implementation_prs)
+                merged_count = sum(1 for pr in effective_prs if pr.state == "merged")
+                total_count = len(effective_prs)
                 open_count = total_count - merged_count
                 prob = max(30, int(70 * merged_count / total_count)) if total_count > 0 else 50
                 vep.analysis["risk_assessment"] = {
@@ -592,12 +680,31 @@ Return updated VEPs with complete analysis, general_insights list, and sheets_ne
         if not has_impl_prs:
             continue
 
-        # Count PRs by state category
+        # Determine effective PRs: filter to current-release only when cutoff available
+        effective_prs = vep.implementation_prs
+        if release_cutoff:
+            current_prs, previous_prs = classify_prs_by_release(vep.implementation_prs, release_cutoff)
+            if previous_prs and not current_prs:
+                ra = vep.analysis["risk_assessment"]
+                prob = ra.get("merge_probability", 100)
+                if prob > 10:
+                    old_prob = prob
+                    phase_info = getattr(vep.current_milestone, 'promotion_phase', 'Net New')
+                    override = _build_previous_release_override(
+                        len(previous_prs), prev_cf_str or "unknown", phase_info, old_prob=old_prob
+                    )
+                    ra.update(override)
+                    log(f"Corrected {vep.name}: only previous-release PRs ({len(previous_prs)}), probability {old_prob}% → 10%", node="analyze_combined")
+                continue
+            elif current_prs:
+                effective_prs = current_prs
+
+        # Count PRs by state category (using current-release PRs only)
         done_states = ("merged", "closed")
-        open_count = sum(1 for pr in vep.implementation_prs if pr.state == "open")
-        done_count = sum(1 for pr in vep.implementation_prs if pr.state in done_states)
-        unknown_count = sum(1 for pr in vep.implementation_prs if pr.state not in (*done_states, "open"))
-        total_count = len(vep.implementation_prs)
+        open_count = sum(1 for pr in effective_prs if pr.state == "open")
+        done_count = sum(1 for pr in effective_prs if pr.state in done_states)
+        unknown_count = sum(1 for pr in effective_prs if pr.state not in (*done_states, "open"))
+        total_count = len(effective_prs)
         # No explicitly open PRs = all done (unknown state = old PR likely merged)
         all_merged = open_count == 0 and done_count > 0
         ra = vep.analysis["risk_assessment"]
@@ -640,7 +747,6 @@ Return updated VEPs with complete analysis, general_insights list, and sheets_ne
         # Some PRs still open — boost if most are done
         elif not all_merged:
             merged_count = done_count
-            total_count = len(vep.implementation_prs)
             if merged_count > 0 and prob < 50:
                 floor = max(50, int(80 * merged_count / total_count))
                 if floor > prob:

--- a/nodes/fetch_veps.py
+++ b/nodes/fetch_veps.py
@@ -326,6 +326,11 @@ def fetch_veps_node(state: VEPState) -> Any:
                             pr.updated_at = datetime.fromisoformat(pr_data["updated_at"].replace('Z', '+00:00'))
                         except (ValueError, AttributeError):
                             pass
+                    if pr_data.get("merged_at"):
+                        try:
+                            pr.merged_at = datetime.fromisoformat(pr_data["merged_at"].replace('Z', '+00:00'))
+                        except (ValueError, AttributeError):
+                            pass
                 enriched_impl_prs.append(pr)
             vep_info.implementation_prs = enriched_impl_prs
 
@@ -354,6 +359,12 @@ def fetch_veps_node(state: VEPState) -> Any:
                                 updated = datetime.fromisoformat(pr_data["updated_at"].replace('Z', '+00:00'))
                         except (ValueError, AttributeError):
                             pass
+                        merged_at = None
+                        if pr_data.get("merged_at"):
+                            try:
+                                merged_at = datetime.fromisoformat(pr_data["merged_at"].replace('Z', '+00:00'))
+                            except (ValueError, AttributeError):
+                                pass
                         pr = PRInfo(
                             number=pr_num,
                             title=pr_data.get("title", f"PR #{pr_num}"),
@@ -362,6 +373,7 @@ def fetch_veps_node(state: VEPState) -> Any:
                             created_at=created,
                             updated_at=updated,
                             author=pr_data.get("author") or "unknown",
+                            merged_at=merged_at,
                         )
                         vep_info.implementation_prs.append(pr)
 
@@ -391,9 +403,14 @@ def fetch_veps_node(state: VEPState) -> Any:
                     now = datetime.now(timezone.utc)
                     created = now
                     updated = now
+                    merged_at = None
                     try:
+                        if pr_data.get("created_at"):
+                            created = datetime.fromisoformat(pr_data["created_at"].replace('Z', '+00:00'))
                         if pr_data.get("updated_at"):
                             updated = datetime.fromisoformat(pr_data["updated_at"].replace('Z', '+00:00'))
+                        if pr_data.get("merged_at"):
+                            merged_at = datetime.fromisoformat(pr_data["merged_at"].replace('Z', '+00:00'))
                     except (ValueError, AttributeError):
                         pass
                     pr = PRInfo(
@@ -404,6 +421,7 @@ def fetch_veps_node(state: VEPState) -> Any:
                         created_at=created,
                         updated_at=updated,
                         author="unknown",
+                        merged_at=merged_at,
                     )
                     vep_info.implementation_prs.append(pr)
 
@@ -416,11 +434,14 @@ def fetch_veps_node(state: VEPState) -> Any:
                 now = datetime.now(timezone.utc)
                 created = now
                 updated = now
+                merged_at = None
                 try:
                     if pr_data.get("created_at"):
                         created = datetime.fromisoformat(pr_data["created_at"].replace('Z', '+00:00'))
                     if pr_data.get("updated_at"):
                         updated = datetime.fromisoformat(pr_data["updated_at"].replace('Z', '+00:00'))
+                    if pr_data.get("merged_at"):
+                        merged_at = datetime.fromisoformat(pr_data["merged_at"].replace('Z', '+00:00'))
                 except (ValueError, AttributeError):
                     pass
                 pr_state = (pr_data.get("state") or "unknown").lower()
@@ -432,6 +453,7 @@ def fetch_veps_node(state: VEPState) -> Any:
                     created_at=created,
                     updated_at=updated,
                     author="unknown",
+                    merged_at=merged_at,
                 )
                 vep_info.enhancement_prs.append(pr)
 

--- a/services/indexer.py
+++ b/services/indexer.py
@@ -152,9 +152,56 @@ def _process_schedule_content(schedule_content: Any, version: str, sorted_versio
         "release_phase": phase,
     }
 
+def _fetch_previous_release_code_freeze(get_file_tool, versions: List[str], current_version: str) -> Optional[str]:
+    """Fetch the previous release's code freeze date.
+
+    The code freeze date is when the release branch is cut from main.
+    PRs merged to main before this date belong to the previous release;
+    PRs merged after belong to the current release.
+
+    Returns ISO date string (e.g. "2026-02-25") or None if unavailable.
+    """
+    # Find the version right after current in the sorted list (sorted newest-first)
+    try:
+        idx = versions.index(current_version)
+    except ValueError:
+        return None
+    if idx + 1 >= len(versions):
+        return None
+
+    prev_version = versions[idx + 1]
+    log(f"Fetching previous release ({prev_version}) code freeze date", node="indexer")
+
+    try:
+        schedule_path = f"releases/{prev_version}/schedule.md"
+        try:
+            schedule_content = get_file_tool.func(
+                owner="kubevirt", repo="sig-release", path=schedule_path
+            )
+        except TypeError:
+            schedule_content = get_file_tool.func(
+                path=f"kubevirt/sig-release/{schedule_path}"
+            )
+
+        if not schedule_content or len(str(schedule_content)) <= 100:
+            log(f"No valid schedule for {prev_version}", node="indexer", level="WARNING")
+            return None
+
+        prev_result = _process_schedule_content(schedule_content, prev_version)
+        cf_date = prev_result.get("release_deadlines", {}).get("code_freeze")
+        if cf_date:
+            log(f"Previous release {prev_version} code freeze: {cf_date}", node="indexer")
+        else:
+            log(f"Could not parse code freeze from {prev_version} schedule", node="indexer", level="WARNING")
+        return cf_date
+    except Exception as e:
+        log(f"Error fetching previous release schedule: {e}", node="indexer", level="WARNING")
+        return None
+
+
 def index_release_schedule() -> Optional[Dict[str, Any]]:
     """Index the current release schedule from kubevirt/sig-release.
-    
+
     Lists the releases directory, finds all versions, sorts numerically,
     and fetches the schedule for the newest release.
     
@@ -308,7 +355,7 @@ def index_release_schedule() -> Optional[Dict[str, Any]]:
                 try:
                     schedule_path = f"releases/{version}/schedule.md"
                     log(f"Trying to fetch schedule for {version}", node="indexer")
-                    
+
                     # Try different parameter formats
                     try:
                         schedule_content = get_file_tool.func(
@@ -328,10 +375,15 @@ def index_release_schedule() -> Optional[Dict[str, Any]]:
                                 path=schedule_path,
                                 branch="main"
                             )
-                    
+
                     if schedule_content and len(str(schedule_content)) > 100:
                         log(f"Found release schedule for {version} ({'newest available' if in_main_loop else 'fallback'})", node="indexer")
-                        return _process_schedule_content(schedule_content, version, sorted_versions if in_main_loop else None)
+                        result = _process_schedule_content(schedule_content, version, sorted_versions if in_main_loop else None)
+                        # Also fetch the previous release's code freeze date
+                        result["previous_release_code_freeze"] = _fetch_previous_release_code_freeze(
+                            get_file_tool, sorted_versions, version
+                        )
+                        return result
                 except Exception as e:
                     log(f"Error fetching schedule for {version}: {e}", node="indexer", level="DEBUG")
                     continue
@@ -351,10 +403,14 @@ def index_release_schedule() -> Optional[Dict[str, Any]]:
                     repo="sig-release",
                     path=schedule_path
                 )
-                
+
                 if schedule_content and len(str(schedule_content)) > 100:
                     log(f"Found release schedule for {version} ({'newest available' if in_main_loop else 'fallback'})", node="indexer")
-                    return _process_schedule_content(schedule_content, version, sorted_versions if in_main_loop else None)
+                    result = _process_schedule_content(schedule_content, version, sorted_versions if in_main_loop else None)
+                    result["previous_release_code_freeze"] = _fetch_previous_release_code_freeze(
+                        get_file_tool, fallback_versions, version
+                    )
+                    return result
             except Exception:
                 continue
                     
@@ -1009,10 +1065,13 @@ def index_enhancements_prs(days_back: Optional[int] = 365) -> List[Dict[str, Any
                     if pr.get("comments"):
                         review_count = max(review_count, pr.get("comments", 0) // 2)
 
+                    is_merged = pr.get("merged", False) or (pr.get("merged_at") is not None)
                     prs.append({
                         "number": pr_number,
                         "title": title,
-                        "state": state,
+                        "state": "merged" if is_merged else state,
+                        "merged": is_merged,
+                        "merged_at": pr.get("merged_at"),
                         "body": body,  # Full body for tracking issue reference extraction
                         "url": url,
                         "html_url": pr.get("html_url", url),
@@ -1131,12 +1190,14 @@ def _search_kubevirt_prs_referencing_veps() -> List[Dict[str, Any]]:
                     vep_issue_num = _extract_vep_issue_number(title, body)
 
                     if vep_issue_num:
-                        is_merged = "pull_request" in item and item.get("pull_request", {}).get("merged_at") is not None
+                        pr_info = item.get("pull_request", {})
+                        is_merged = "pull_request" in item and pr_info.get("merged_at") is not None
                         all_prs.append({
                             "number": pr_num,
                             "title": title,
                             "state": "merged" if is_merged else item.get("state", ""),
                             "merged": is_merged,
+                            "merged_at": pr_info.get("merged_at"),
                             "url": item.get("html_url") or item.get("url", ""),
                             "html_url": item.get("html_url", ""),
                             "created_at": item.get("created_at"),
@@ -1301,6 +1362,7 @@ def index_kubevirt_prs(days_back: Optional[int] = 365, fetch_reviews: bool = Tru
                             "labels": [l.get("name") if isinstance(l, dict) else l for l in pr.get("labels", [])],
                             "state": "merged" if is_merged else pr.get("state"),
                             "merged": is_merged,
+                            "merged_at": pr.get("merged_at"),
                             "url": pr.get("html_url") or pr.get("url"),
                             "created_at": pr.get("created_at"),
                             "updated_at": pr.get("updated_at"),
@@ -2061,8 +2123,10 @@ def index_vep_pr_mappings(prs_index: Optional[List[Dict[str, Any]]] = None) -> D
                 "title": pr.get("title"),
                 "state": pr.get("state"),
                 "merged": pr.get("merged", False),
+                "merged_at": pr.get("merged_at"),
                 "url": pr.get("html_url") or pr.get("url"),
                 "labels": pr.get("labels", []),
+                "created_at": pr.get("created_at"),
                 "updated_at": pr.get("updated_at"),
             })
 
@@ -2536,6 +2600,8 @@ def create_indexed_context(days_back: Optional[int] = 365, cache_max_age_minutes
                         if not existing.get("merged") and pr.get("merged"):
                             existing["merged"] = pr["merged"]
                             existing["state"] = "merged"
+                        if not existing.get("merged_at") and pr.get("merged_at"):
+                            existing["merged_at"] = pr["merged_at"]
                         break
         log(f"Search merge: {new_count} new PRs added, {updated_count} existing PRs updated with VEP issue numbers", node="indexer")
 
@@ -2568,6 +2634,7 @@ def create_indexed_context(days_back: Optional[int] = 365, cache_max_age_minutes
     }
     indexed_context["release_phase"] = release_info.get("release_phase", "unknown") if release_info else "unknown"
     indexed_context["release_deadlines"] = release_info.get("release_deadlines", {}) if release_info else {}
+    indexed_context["previous_release_code_freeze"] = release_info.get("previous_release_code_freeze") if release_info else None
 
     # Log summary
     release = release_version if release_version else "unknown"


### PR DESCRIPTION
## Summary

Previous-release PRs are now filtered out when assessing VEP completeness - only current-release PRs matter. The cutoff is the previous release's code freeze date plus a 7-day buffer for delayed branch cuts.

## Problem

VEPs on the v1.9 board were showing GREEN/100% when all their implementation PRs were merged during the v1.8 release cycle. The agent checked only PR state (merged/open), not *when* merged.

## Approach

The agent fetches the previous release's code freeze date from `kubevirt/sig-release`, adds a 7-day buffer (to account for delayed branch cuts), and uses this as the cutoff. PRs merged before the cutoff are filtered out entirely. Assessment, counting, and corrections all operate on current-release PRs only.

Applied in three defensive layers: LLM prompt instruction, pre-LLM fallback cascade, and post-LLM correction cascade.

## Validation

Full cycle run with before/after snapshot comparison.

- [Baseline snapshot](https://pastebin.com/kjBuFGDs) (before fix)
- [Snapshot after fix](https://pastebin.com/susTTzFm) (first run, without buffer)

### VEPs correctly dropped to 10% (only previous-release PRs)

| VEP | Baseline | Fixed |
|-----|----------|-------|
| vep-0017 | 25% | 10% |
| vep-0062 | 100% | 10% |
| vep-0076 | 95% | 10% |
| vep-0090 | 100% | 10% |
| vep-0103 | 100% | 10% |
| vep-0106 | 100% | 10% |
| vep-0108 | 95% | 10% |
| vep-0141 | 95% | 10% |
| vep-0156 | 95% | 10% |
| vep-0160 | 95% | 10% |
| vep-0171 | 95% | 10% |
| vep-0196 | 95% | 10% |

### VEPs with genuine current-release work - preserved

| VEP | Baseline | Fixed |
|-----|----------|-------|
| vep-0025 | 95% | 100% |

No regressions - no VEP with genuine current-release work was incorrectly penalized.

## Test plan

- [x] Ruff lint passes
- [x] Import smoke test passes
- [x] Full cycle snapshot validation - 12 VEPs correctly dropped, no regressions