### PR TITLE
Filter backport PRs, add per-cycle snapshots and SIGTERM handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ graph TD
     MergeUpdates --> AnalyzeCombined[analyze_combined]
     AnalyzeCombined --> DetectChanges[detect_changes]
     DetectChanges --> SaveStateCache[save_state_cache]
-    SaveStateCache --> Scheduler
+    SaveStateCache --> Snapshot[snapshot]
+    Snapshot --> Scheduler
 
     AlertSummary -->|Alerts| SendNotifications[send_notifications]
     AlertSummary -->|No alerts| Scheduler

--- a/graph.py
+++ b/graph.py
@@ -24,6 +24,7 @@ from nodes.send_email import send_email_node
 from nodes.send_slack import send_slack_node
 from nodes.update_project_board import update_project_board_node
 from nodes.wait import wait_node
+from nodes.snapshot import snapshot_node
 
 def create_graph() -> CompiledStateGraph[Any, Any, Any, Any]:
     """Create and configure the VEP governance agent graph.
@@ -66,6 +67,7 @@ def create_graph() -> CompiledStateGraph[Any, Any, Any, Any]:
     workflow.add_node("send_slack", send_slack_node)
     workflow.add_node("update_project_board", update_project_board_node)
     workflow.add_node("wait", wait_node)
+    workflow.add_node("snapshot", snapshot_node)
     
     # Set entry point
     workflow.set_entry_point("scheduler")
@@ -108,7 +110,8 @@ def create_graph() -> CompiledStateGraph[Any, Any, Any, Any]:
     # Analysis completes → detect changes vs previous run → save state cache → scheduler
     workflow.add_edge("analyze_combined", "detect_changes")
     workflow.add_edge("detect_changes", "save_state_cache")
-    workflow.add_edge("save_state_cache", "scheduler")
+    workflow.add_edge("save_state_cache", "snapshot")
+    workflow.add_edge("snapshot", "scheduler")
     
     # Alert summary decides if notifications needed, then routes to send_notifications or scheduler
     workflow.add_conditional_edges(
@@ -154,9 +157,12 @@ def route_scheduler_operations(state: VEPState) -> str:
     by routing to them sequentially. The scheduler queues tasks and processes
     them one at a time, returning to scheduler after each completes.
     """
+    from services.shutdown import is_shutdown_requested
+    if is_shutdown_requested():
+        return END
+
     import os
     debug_mode = os.environ.get("DEBUG_MODE")
-    # In one-cycle mode or test-sheets debug mode, if sheet update completed, terminate the graph
     if (state.get("one_cycle", False) or debug_mode == "test-sheets") and state.get("_exit_after_sheets", False):
         return END
     

--- a/main.py
+++ b/main.py
@@ -11,14 +11,13 @@ from typing import Optional, Dict, Any
 from langchain_core.messages import HumanMessage
 from graph import create_graph
 from services.utils import log
+from services.shutdown import is_shutdown_requested, request_shutdown
 from state import VEPInfo, ReleaseSchedule
 from nodes.state_history import clear_all_history
 from nodes.escalation import clear_persistence
 
 # State cache file location
 STATE_CACHE_FILE = Path(__file__).parent / "cache" / "state_cache.json"
-
-from services.shutdown import is_shutdown_requested, request_shutdown
 
 
 def load_state_cache() -> Optional[Dict[str, Any]]:

--- a/main.py
+++ b/main.py
@@ -6,7 +6,6 @@ import json
 import os
 import signal
 import sys
-import time
 from pathlib import Path
 from typing import Optional, Dict, Any
 from langchain_core.messages import HumanMessage
@@ -15,13 +14,11 @@ from services.utils import log
 from state import VEPInfo, ReleaseSchedule
 from nodes.state_history import clear_all_history
 from nodes.escalation import clear_persistence
-from nodes.snapshot import dump_snapshot, generate_realizations
 
 # State cache file location
 STATE_CACHE_FILE = Path(__file__).parent / "cache" / "state_cache.json"
 
-# Global flag for graceful shutdown
-_shutdown_requested = False
+from services.shutdown import is_shutdown_requested, request_shutdown
 
 
 def load_state_cache() -> Optional[Dict[str, Any]]:
@@ -348,15 +345,14 @@ def parse_args():
 
 
 def signal_handler(signum, frame):
-    """Handle SIGINT (Ctrl+C) gracefully."""
-    global _shutdown_requested
-    if _shutdown_requested:
-        # Second Ctrl+C - force exit
+    """Handle SIGINT/SIGTERM gracefully."""
+    if is_shutdown_requested():
         log("\nForce exit requested. Terminating...", node="main", level="WARNING")
-        sys.exit(130)  # Standard exit code for SIGINT
+        sys.exit(130)
     else:
-        _shutdown_requested = True
-        log("\nShutdown requested (Ctrl+C). Finishing current operation and exiting gracefully...", node="main", level="INFO")
+        request_shutdown()
+        sig_name = "SIGTERM" if signum == signal.SIGTERM else "SIGINT"
+        log(f"\nShutdown requested ({sig_name}). Finishing current operation...", node="main", level="INFO")
 
 
 def setup_credentials(args):
@@ -422,22 +418,11 @@ def setup_credentials(args):
         log("Fastest model mode enabled: all nodes will use FAST_MODEL", node="main")
 
 
-def _try_snapshot(response, start_time: float) -> None:
-    """Write snapshot and realizations, swallowing errors."""
-    try:
-        elapsed = time.time() - start_time
-        dump_snapshot(response, cycle_duration=elapsed)
-        generate_realizations(response, cycle_duration=elapsed)
-    except Exception as e:
-        log(f"Snapshot failed: {e}", node="main", level="ERROR")
-
-
 def main():
     """Run the VEP governance agent."""
-    global _shutdown_requested
-
-    # Register signal handler for graceful shutdown
+    # Register signal handlers for graceful shutdown
     signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
 
     # Parse command line arguments
     args = parse_args()
@@ -513,8 +498,7 @@ def main():
     log(f"Sheet config: {initial_state['sheet_config']}", node="main")
     
     # Run the agent
-    start_time = time.time()
-    response = initial_state  # Ensure response is always defined for finally block
+    response = initial_state
     try:
         if args.one_cycle:
             # In one-cycle mode, run until update_sheets completes
@@ -527,7 +511,7 @@ def main():
                 iteration += 1
                 response = agent.invoke(current_state)
 
-                if _shutdown_requested:
+                if is_shutdown_requested():
                     log("Agent interrupted by user. Exiting...", node="main", level="INFO")
                     return
 
@@ -550,7 +534,7 @@ def main():
             log("Invoking agent...", node="main")
             response = agent.invoke(initial_state)
 
-        if _shutdown_requested:
+        if is_shutdown_requested():
             log("Agent interrupted by user. Exiting...", node="main", level="INFO")
             return
 
@@ -569,15 +553,13 @@ def main():
         log("\nInterrupted by user. Exiting gracefully...", node="main", level="INFO")
         sys.exit(130)
     except Exception as e:
-        if _shutdown_requested:
+        if is_shutdown_requested():
             log(f"Error occurred during shutdown: {e}", node="main", level="WARNING")
             sys.exit(130)
         log(f"Error running agent: {e}", node="main", level="ERROR")
         import traceback
         log(f"Traceback: {traceback.format_exc()}", node="main", level="ERROR")
         raise
-    finally:
-        _try_snapshot(response, start_time)
 
 
 if __name__ == "__main__":

--- a/nodes/alert_formatting.py
+++ b/nodes/alert_formatting.py
@@ -8,6 +8,7 @@ Provides utilities to build per-VEP summary tables with:
 """
 
 import re
+from datetime import date, datetime
 from typing import List, Dict, Any, Tuple
 from services.indexer import create_indexed_context
 from services.utils import log
@@ -250,6 +251,31 @@ def build_vep_summary_table(veps: List[Any], indexed_context: Dict[str, Any] = N
         if removed:
             log(f"VEP {vep.name}: filtered {removed} backport impl PR(s)",
                 node="alert_formatting")
+
+        # Filter out merged PRs from before the current release cycle
+        cycle_start_date = indexed_context.get("cycle_start_date")
+        if cycle_start_date:
+            cycle_start = date.fromisoformat(cycle_start_date)
+            before_count = len(impl_prs)
+            filtered = []
+            for p in impl_prs:
+                merged_at = p.get("_merged_at")
+                if merged_at:
+                    try:
+                        if isinstance(merged_at, datetime):
+                            merged_date = merged_at.date()
+                        else:
+                            merged_date = datetime.fromisoformat(merged_at).date()
+                        if merged_date < cycle_start:
+                            continue
+                    except (ValueError, TypeError):
+                        pass
+                filtered.append(p)
+            impl_prs = filtered
+            removed = before_count - len(impl_prs)
+            if removed:
+                log(f"VEP {vep.name}: filtered {removed} pre-cycle impl PR(s) (cycle start: {cycle_start_date})",
+                    node="alert_formatting")
 
         # Strip internal fields before output
         impl_prs = [{"number": p["number"], "url": p["url"]} for p in impl_prs]

--- a/nodes/alert_formatting.py
+++ b/nodes/alert_formatting.py
@@ -71,6 +71,7 @@ def build_vep_summary_table(veps: List[Any], indexed_context: Dict[str, Any] = N
         indexed_context = create_indexed_context(cache_max_age_minutes=60)
 
     enhancements_prs = indexed_context.get("enhancements_prs", [])
+    enhancements_by_number = {pr.get("number"): pr for pr in enhancements_prs}
     board_veps = indexed_context.get("board_veps", {})
     issues_index = indexed_context.get("issues_index", [])
 
@@ -130,13 +131,43 @@ def build_vep_summary_table(veps: List[Any], indexed_context: Dict[str, Any] = N
             if pr.get("vep_issue_number") == vep.tracking_issue_id:
                 proposal_pr_numbers.add(pr.get("number"))
 
-        # Build proposal PRs list with URLs
+        # Build proposal PRs list with URLs and merged_at for filtering
         proposal_prs = []
         for pr_num in sorted(proposal_pr_numbers):
+            enh_pr = enhancements_by_number.get(pr_num, {})
             proposal_prs.append({
                 "number": pr_num,
                 "url": f"https://github.com/kubevirt/enhancements/pull/{pr_num}",
+                "_merged_at": enh_pr.get("merged_at"),
             })
+
+        # Filter out proposal PRs merged before the current release cycle
+        cycle_start_date_str = indexed_context.get("cycle_start_date")
+        if cycle_start_date_str:
+            cycle_start = date.fromisoformat(cycle_start_date_str)
+            before_count = len(proposal_prs)
+            filtered = []
+            for p in proposal_prs:
+                merged_at = p.get("_merged_at")
+                if merged_at:
+                    try:
+                        if isinstance(merged_at, datetime):
+                            merged_date = merged_at.date()
+                        else:
+                            merged_date = datetime.fromisoformat(merged_at).date()
+                        if merged_date < cycle_start:
+                            continue
+                    except (ValueError, TypeError):
+                        pass
+                filtered.append(p)
+            proposal_prs = filtered
+            removed = before_count - len(proposal_prs)
+            if removed:
+                log(f"VEP {vep.name}: filtered {removed} pre-cycle proposal PR(s) (cycle start: {cycle_start_date_str})",
+                    node="alert_formatting")
+
+        # Strip internal fields from proposal PRs
+        proposal_prs = [{"number": p["number"], "url": p["url"]} for p in proposal_prs]
 
         # Get implementation PRs from multiple sources
         # IMPORTANT: Implementation PRs can NEVER be from kubevirt/enhancements (those are proposal PRs)

--- a/nodes/alert_formatting.py
+++ b/nodes/alert_formatting.py
@@ -8,7 +8,6 @@ Provides utilities to build per-VEP summary tables with:
 """
 
 import re
-from datetime import date, datetime, time, timedelta, timezone
 from typing import List, Dict, Any, Tuple
 from services.indexer import create_indexed_context
 from services.utils import log
@@ -74,17 +73,11 @@ def build_vep_summary_table(veps: List[Any], indexed_context: Dict[str, Any] = N
     board_veps = indexed_context.get("board_veps", {})
     issues_index = indexed_context.get("issues_index", [])
 
-    # Parse previous release cutoff for filtering previous-release impl PRs
-    # (uses the same cutoff as classify_prs_by_release() in analyze_combined.py)
-    release_cutoff = None
-    prev_cf_str = indexed_context.get("previous_release_code_freeze")
-    if prev_cf_str:
-        try:
-            release_cutoff = datetime.combine(
-                date.fromisoformat(prev_cf_str), time.min, tzinfo=timezone.utc
-            ) + timedelta(days=7)
-        except (ValueError, TypeError):
-            pass
+    # Build base_ref lookup from prs_index for filtering backport impl PRs
+    prs_by_number = {}
+    for pr in indexed_context.get("prs_index", []):
+        if isinstance(pr, dict) and pr.get("number"):
+            prs_by_number[pr["number"]] = pr
 
     # Build a lookup from issue number to issue data
     issues_by_number = {}
@@ -189,8 +182,10 @@ def build_vep_summary_table(veps: List[Any], indexed_context: Dict[str, Any] = N
             if pr.get("vep_issue_number") == vep.tracking_issue_id:
                 pr_num = pr.get("number")
                 pr_url = pr.get("url", f"https://github.com/kubevirt/kubevirt/pull/{pr_num}")
-                # Skip enhancements PRs (safety check)
                 if "enhancements" in pr_url:
+                    continue
+                base_ref = pr.get("base_ref")
+                if base_ref and base_ref not in ("main", "master"):
                     continue
                 if pr_num and pr_num not in impl_pr_numbers:
                     impl_pr_numbers.add(pr_num)
@@ -211,6 +206,13 @@ def build_vep_summary_table(veps: List[Any], indexed_context: Dict[str, Any] = N
             pr_num = pr.get("number")
             pr_url = pr.get("url", f"https://github.com/kubevirt/kubevirt/pull/{pr_num}")
             if "enhancements" in pr_url:
+                continue
+            base_ref = pr.get("base_ref")
+            if not base_ref and pr_num:
+                idx = prs_by_number.get(pr_num)
+                if idx:
+                    base_ref = idx.get("base_ref")
+            if base_ref and base_ref not in ("main", "master"):
                 continue
             # Skip if PR title references a different VEP number
             pr_title = pr.get("title", "")
@@ -233,30 +235,21 @@ def build_vep_summary_table(veps: List[Any], indexed_context: Dict[str, Any] = N
         # Sort by PR number
         impl_prs = sorted(impl_prs, key=lambda x: x["number"])
 
-        # Filter out previous-release PRs using the pre-parsed cutoff
-        if release_cutoff:
-            before_count = len(impl_prs)
-            filtered = []
-            for p in impl_prs:
-                state = p.get("_state")
-                merged_at = p.get("_merged_at")
-                # Parse ISO string to datetime if needed
-                if isinstance(merged_at, str):
-                    try:
-                        merged_at = datetime.fromisoformat(merged_at.replace("Z", "+00:00"))
-                    except (ValueError, TypeError):
-                        merged_at = None
-                if isinstance(merged_at, datetime) and merged_at.tzinfo is None:
-                    merged_at = merged_at.replace(tzinfo=timezone.utc)
-                # Keep unless confirmed previous-release
-                if state == "merged" and merged_at and merged_at < release_cutoff:
+        # Filter out backport PRs (targeting release branches, not main)
+        before_count = len(impl_prs)
+        filtered = []
+        for p in impl_prs:
+            pr_index_data = prs_by_number.get(p["number"])
+            if pr_index_data:
+                base_ref = pr_index_data.get("base_ref")
+                if base_ref and base_ref not in ("main", "master"):
                     continue
-                filtered.append(p)
-            impl_prs = filtered
-            removed = before_count - len(impl_prs)
-            if removed:
-                log(f"VEP {vep.name}: filtered {removed} previous-release impl PR(s)",
-                    node="alert_formatting")
+            filtered.append(p)
+        impl_prs = filtered
+        removed = before_count - len(impl_prs)
+        if removed:
+            log(f"VEP {vep.name}: filtered {removed} backport impl PR(s)",
+                node="alert_formatting")
 
         # Strip internal fields before output
         impl_prs = [{"number": p["number"], "url": p["url"]} for p in impl_prs]

--- a/nodes/analyze_combined.py
+++ b/nodes/analyze_combined.py
@@ -5,7 +5,7 @@ This node has access to ALL context at once and does holistic reasoning.
 """
 
 import json
-from datetime import datetime, date, time, timedelta, timezone
+from datetime import datetime, date, time, timezone
 from typing import Any, List, Optional, Tuple
 from state import VEPState, PRInfo
 from services.utils import log
@@ -18,9 +18,9 @@ from nodes.alert_formatting import build_vep_summary_table, build_markdown_table
 def classify_prs_by_release(impl_prs: List[PRInfo], cutoff: datetime) -> Tuple[List[PRInfo], List[PRInfo]]:
     """Classify implementation PRs as current-release vs previous-release work.
 
-    The cutoff is the previous release's code freeze date (when its branch was
-    cut from main). PRs merged to main before that date belong to the previous
-    release; PRs merged after or still open belong to the current release.
+    The cutoff is the cycle start date (first date in the release schedule, or
+    previous CF + 14d fallback). PRs merged before the cutoff belong to the
+    previous release; PRs merged after or still open belong to the current release.
 
     Returns (current_release_prs, previous_release_prs).
     Closed-not-merged (abandoned) PRs are excluded from both lists.
@@ -52,8 +52,8 @@ def _build_previous_release_override(
 ) -> dict:
     """Build risk assessment dict for VEPs with only previous-release PRs."""
     reasoning = (
-        f"All {num_previous_prs} implementation PRs merged before previous release "
-        f"code freeze ({cutoff_str}), no current-release activity. "
+        f"All {num_previous_prs} implementation PRs merged before cycle start "
+        f"({cutoff_str}), no current-release activity. "
         f"Promotion phase: {phase_info}."
     )
     if old_prob is not None:
@@ -205,21 +205,19 @@ def analyze_combined_node(state: VEPState) -> Any:
     release_deadlines = indexed_context.get("release_deadlines", {})
     board_veps = indexed_context.get("board_veps", {})
 
-    # Parse previous release code freeze cutoff for release-aware PR classification
-    prev_cf_str = indexed_context.get("previous_release_code_freeze")
+    # Parse cycle start date for release-aware PR classification
+    cycle_start_str = indexed_context.get("cycle_start_date")
     release_cutoff: Optional[datetime] = None
-    if prev_cf_str:
+    if cycle_start_str:
         try:
-            # Add 7-day buffer after the scheduled code freeze to account for
-            # the community delaying the actual branch cut by up to a week
             release_cutoff = datetime.combine(
-                date.fromisoformat(prev_cf_str), time.min, tzinfo=timezone.utc
-            ) + timedelta(days=7)
-            log(f"Release cutoff for PR classification: {prev_cf_str} + 7d buffer = {release_cutoff.date().isoformat()}", node="analyze_combined")
+                date.fromisoformat(cycle_start_str), time.min, tzinfo=timezone.utc
+            )
+            log(f"Release cutoff for PR classification: cycle_start_date={cycle_start_str}", node="analyze_combined")
         except (ValueError, TypeError):
-            log(f"Could not parse previous_release_code_freeze: {prev_cf_str}", node="analyze_combined", level="WARNING")
+            log(f"Could not parse cycle_start_date: {cycle_start_str}", node="analyze_combined", level="WARNING")
     else:
-        log("Release-aware PR classification disabled: no previous release code freeze date available", node="analyze_combined", level="WARNING")
+        log("Release-aware PR classification disabled: no cycle_start_date available", node="analyze_combined", level="WARNING")
 
     # Extract phase_risks from VEPs for focused analysis
     phase_risks = []
@@ -510,7 +508,7 @@ For EVERY VEP (skip any with "_deterministic_risk" in analysis):
 8. Recommend escalation if probability < 50% OR blocked OR no recent_progress
 9. Store in vep.analysis["risk_assessment"] with recent_progress and days_inactive fields
 
-RELEASE-AWARENESS: PRs merged before the previous release's code freeze ({prev_cf_str or 'unknown'})
+RELEASE-AWARENESS: PRs merged before the cycle start date ({cycle_start_str or 'unknown'})
 are PREVIOUS-RELEASE work, not current-release progress. Ignore previous-release PRs when assessing
 completeness - only current-release PRs matter. A VEP with no current-release PRs should have LOW
 probability (around 10%), regardless of how many previous-release PRs were merged.
@@ -612,7 +610,7 @@ Return updated VEPs with complete analysis, general_insights list, and sheets_ne
                 if previous_prs and not current_prs:
                     phase_info = getattr(vep.current_milestone, 'promotion_phase', 'Net New')
                     vep.analysis["risk_assessment"] = _build_previous_release_override(
-                        len(previous_prs), prev_cf_str or "unknown", phase_info
+                        len(previous_prs), cycle_start_str or "unknown", phase_info
                     )
                     log(f"Fallback: {vep.name} has only previous-release PRs ({len(previous_prs)}), prob=10%", node="analyze_combined")
                     continue
@@ -693,7 +691,7 @@ Return updated VEPs with complete analysis, general_insights list, and sheets_ne
                     old_prob = prob
                     phase_info = getattr(vep.current_milestone, 'promotion_phase', 'Net New')
                     override = _build_previous_release_override(
-                        len(previous_prs), prev_cf_str or "unknown", phase_info, old_prob=old_prob
+                        len(previous_prs), cycle_start_str or "unknown", phase_info, old_prob=old_prob
                     )
                     ra.update(override)
                     log(f"Corrected {vep.name}: only previous-release PRs ({len(previous_prs)}), probability {old_prob}% → 10%", node="analyze_combined")

--- a/nodes/analyze_combined.py
+++ b/nodes/analyze_combined.py
@@ -460,15 +460,17 @@ and issue category - consolidate related issues into a single alert."""
         batch_phase_risks = [r for r in phase_risks if r["vep_name"] in {v.name for v in batch_veps}]
 
         release_schedule = state.get("release_schedule")
-        # During design phase, exclude implementation PRs from LLM context — they're not relevant yet
-        if release_phase == "design":
-            veps_data = []
-            for vep in batch_veps:
-                d = vep.model_dump(mode='json')
+        # Strip raw board impl_prs from LLM context to prevent backport PR leaks.
+        # The filtered implementation_prs field is the authoritative source.
+        veps_data = []
+        for vep in batch_veps:
+            d = vep.model_dump(mode='json')
+            if release_phase == "design":
                 d.pop("implementation_prs", None)
-                veps_data.append(d)
-        else:
-            veps_data = [vep.model_dump(mode='json') for vep in batch_veps]
+            board = d.get("board_fields")
+            if isinstance(board, dict):
+                board.pop("impl_prs", None)
+            veps_data.append(d)
 
         batch_context = {
             "veps": veps_data,
@@ -548,11 +550,11 @@ Return updated VEPs with complete analysis, general_insights list, and sheets_ne
                         updated_vep.analysis = {}
                     updated_vep.analysis["risk_assessment"] = orig_analysis["risk_assessment"]
                     updated_vep.analysis["_deterministic_risk"] = True
-                if not updated_vep.implementation_prs and original.implementation_prs:
+                if original.implementation_prs:
                     updated_vep.implementation_prs = original.implementation_prs
-                if not updated_vep.enhancement_prs and original.enhancement_prs:
+                if original.enhancement_prs:
                     updated_vep.enhancement_prs = original.enhancement_prs
-                if not updated_vep.board_fields and original.board_fields:
+                if original.board_fields:
                     updated_vep.board_fields = original.board_fields
                 if not updated_vep.context.deadline and original.context.deadline:
                     updated_vep.context.deadline = original.context.deadline

--- a/nodes/check_phase_risks.py
+++ b/nodes/check_phase_risks.py
@@ -231,6 +231,7 @@ def _check_development_phase_risks(
     vep_to_pr_mappings = indexed_context.get("vep_to_pr_mappings", {})
 
     risks_by_vep = {}
+    prs_by_number = {pr.get("number"): pr for pr in prs_index if isinstance(pr, dict)}
 
     # Check each board VEP for implementation status
     for vep_issue_num, board_vep in board_veps.items():
@@ -243,11 +244,12 @@ def _check_development_phase_risks(
         # Collect implementation PRs from all sources
         impl_pr_numbers = set()
         impl_prs = []
-
-        # Source 1: Board data (parsed from tracking issue body)
         for pr in board_vep.get("impl_prs", []):
             pr_num = pr.get("number")
-            if pr_num and pr_num not in impl_pr_numbers:
+            if pr_num and pr_num not in impl_pr_numbers and pr_num in prs_by_number:
+                base_ref = prs_by_number[pr_num].get("base_ref")
+                if base_ref and base_ref not in ("main", "master"):
+                    continue
                 impl_pr_numbers.add(pr_num)
                 impl_prs.append(pr)
 
@@ -255,6 +257,13 @@ def _check_development_phase_risks(
         vep_num_str = str(vep_issue_num)
         for pr in vep_to_pr_mappings.get(vep_num_str, []):
             pr_num = pr.get("number")
+            base_ref = pr.get("base_ref")
+            if not base_ref and pr_num:
+                idx = prs_by_number.get(pr_num)
+                if idx:
+                    base_ref = idx.get("base_ref")
+            if base_ref and base_ref not in ("main", "master"):
+                continue
             if pr_num and pr_num not in impl_pr_numbers:
                 impl_pr_numbers.add(pr_num)
                 impl_prs.append(pr)
@@ -265,6 +274,9 @@ def _check_development_phase_risks(
                 pr_num = pr.get("number")
                 pr_url = pr.get("html_url") or pr.get("url", "")
                 if "enhancements" in pr_url:
+                    continue
+                base_ref = pr.get("base_ref")
+                if base_ref and base_ref not in ("main", "master"):
                     continue
                 if pr_num and pr_num not in impl_pr_numbers:
                     impl_pr_numbers.add(pr_num)

--- a/nodes/fetch_veps.py
+++ b/nodes/fetch_veps.py
@@ -82,7 +82,7 @@ def _create_vep_from_board_item(
 ) -> Optional[VEPInfo]:
     """Create VEPInfo from board item, enriching with issue and file data."""
 
-    tracking_issue_id = issue_number
+    tracking_issue_id = int(issue_number)
 
     # Get corresponding issue
     issue = issues_by_number.get(tracking_issue_id)
@@ -331,7 +331,11 @@ def fetch_veps_node(state: VEPState) -> Any:
                             pr.merged_at = datetime.fromisoformat(pr_data["merged_at"].replace('Z', '+00:00'))
                         except (ValueError, AttributeError):
                             pass
-                enriched_impl_prs.append(pr)
+                    enriched_impl_prs.append(pr)
+                else:
+                    log(f"VEP {vep_info.name}: dropping board PR #{pr.number} "
+                        f"(not in prs_index, likely outside lookback window)",
+                        node="fetch_veps")
             vep_info.implementation_prs = enriched_impl_prs
 
             # Also add implementation PRs discovered via vep_issue_number in prs_index
@@ -390,7 +394,12 @@ def fetch_veps_node(state: VEPState) -> Any:
                 if "enhancements" in pr_url:
                     continue
                 # Skip backport PRs (PRs targeting non-main branches like release-1.x)
+                # vep_to_pr_mappings may lack base_ref; fall back to prs_index
                 base_ref = pr_data.get("base_ref")
+                if not base_ref and pr_num:
+                    idx = kubevirt_prs_by_number.get(pr_num)
+                    if idx:
+                        base_ref = idx.get("base_ref")
                 if base_ref and base_ref not in ("main", "master"):
                     continue
                 # Skip if PR title references a different VEP number

--- a/nodes/fetch_veps.py
+++ b/nodes/fetch_veps.py
@@ -94,7 +94,7 @@ def _create_vep_from_board_item(
     vep_number = _extract_vep_number_from_text(title)
     if not vep_number:
         # Fallback: use tracking issue number
-        vep_number = f"vep-{tracking_issue_id:04d}"
+        vep_number = f"vep-{int(tracking_issue_id):04d}"
 
     # Get VEP file for this VEP number
     vep_number_int = int(vep_number.split("-")[1]) if "-" in vep_number else None

--- a/nodes/scheduler.py
+++ b/nodes/scheduler.py
@@ -89,6 +89,10 @@ def scheduler_node(state: VEPState) -> Any:
     
     The scheduler ensures the analysis pipeline runs before updating sheets or sending emails.
     """
+    from services.shutdown import is_shutdown_requested
+    if is_shutdown_requested():
+        return {"next_tasks": []}
+
     last_check_times = state.get("last_check_times", {})
     next_tasks: List[str] = []
     one_cycle = state.get("one_cycle", False)

--- a/nodes/snapshot.py
+++ b/nodes/snapshot.py
@@ -150,6 +150,33 @@ def generate_realizations(state: VEPState, cycle_duration: float = 0) -> None:
         node="snapshot")
 
 
+def snapshot_node(state: VEPState) -> Any:
+    """Graph node that writes per-cycle snapshot and realizations."""
+    import time as _time
+
+    last_checks = state.get("last_check_times", {})
+    fetch_time = last_checks.get("fetch_veps")
+    cycle_duration = 0.0
+    if fetch_time:
+        try:
+            epoch = fetch_time.timestamp() if hasattr(fetch_time, 'timestamp') else 0
+            cycle_duration = _time.time() - epoch
+        except Exception:
+            pass
+
+    try:
+        dump_snapshot(state, cycle_duration=cycle_duration)
+    except Exception as e:
+        log(f"Snapshot failed: {e}", node="snapshot", level="ERROR")
+
+    try:
+        generate_realizations(state, cycle_duration=cycle_duration)
+    except Exception as e:
+        log(f"Realizations failed: {e}", node="snapshot", level="ERROR")
+
+    return {"last_check_times": {"snapshot": datetime.now()}}
+
+
 # -- Internal helpers --
 
 

--- a/nodes/wait.py
+++ b/nodes/wait.py
@@ -1,6 +1,5 @@
 """Wait node - waits until next round hour before returning to scheduler."""
 
-import time
 from datetime import datetime, timedelta
 from typing import Any
 from state import VEPState
@@ -47,12 +46,8 @@ def wait_node(state: VEPState) -> Any:
         node="wait"
     )
     
-    # Sleep until target time (with interruptible wait)
-    try:
-        time.sleep(wait_seconds)
-    except KeyboardInterrupt:
-        log("Wait interrupted by user", node="wait", level="INFO")
-        raise
-    
-    # After waiting, return to scheduler (which will check what needs to run)
+    from services.shutdown import wait_for_shutdown
+    if wait_for_shutdown(timeout=wait_seconds):
+        log("Wait interrupted by shutdown signal", node="wait", level="INFO")
+
     return {}

--- a/services/indexer.py
+++ b/services/indexer.py
@@ -2128,6 +2128,7 @@ def index_vep_pr_mappings(prs_index: Optional[List[Dict[str, Any]]] = None) -> D
                 "labels": pr.get("labels", []),
                 "created_at": pr.get("created_at"),
                 "updated_at": pr.get("updated_at"),
+                "base_ref": pr.get("base_ref"),
             })
 
     total_prs = sum(len(prs) for prs in mappings.values())

--- a/services/indexer.py
+++ b/services/indexer.py
@@ -10,7 +10,7 @@ import os
 import time
 from pathlib import Path
 from typing import Dict, List, Any, Optional
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from services.utils import log
 from services.mcp_factory import get_mcp_tools_by_name
 
@@ -2391,6 +2391,7 @@ def compute_release_phase(release_info: dict) -> tuple[str, dict[str, str | None
         "code_freeze": None,
         "ga": None,
     }
+    earliest_schedule_date = None
 
     for line in schedule_content.splitlines():
         line_clean = line.replace("**", "").strip()
@@ -2402,6 +2403,9 @@ def compute_release_phase(release_info: dict) -> tuple[str, dict[str, str | None
         if not parsed_date:
             continue
         date_obj = parsed_date.date()
+
+        if earliest_schedule_date is None or date_obj < earliest_schedule_date:
+            earliest_schedule_date = date_obj
 
         line_lower = line_clean.lower()
 
@@ -2456,6 +2460,7 @@ def compute_release_phase(release_info: dict) -> tuple[str, dict[str, str | None
         key: date.isoformat() if date else None
         for key, date in dates.items()
     }
+    deadlines["cycle_start"] = earliest_schedule_date.isoformat() if earliest_schedule_date else None
 
     log(f"Final parsed deadlines: {deadlines}, phase: {phase}", node="indexer")
 
@@ -2636,6 +2641,24 @@ def create_indexed_context(days_back: Optional[int] = 365, cache_max_age_minutes
     indexed_context["release_phase"] = release_info.get("release_phase", "unknown") if release_info else "unknown"
     indexed_context["release_deadlines"] = release_info.get("release_deadlines", {}) if release_info else {}
     indexed_context["previous_release_code_freeze"] = release_info.get("previous_release_code_freeze") if release_info else None
+
+    # Compute cycle_start_date: earliest schedule date (primary) or prev CF + 14d (fallback)
+    cycle_start_date = None
+    deadlines = indexed_context.get("release_deadlines", {})
+    cycle_start_from_schedule = deadlines.get("cycle_start")
+    if cycle_start_from_schedule:
+        cycle_start_date = cycle_start_from_schedule
+        log(f"Cycle start date from schedule: {cycle_start_date}", node="indexer")
+    elif indexed_context["previous_release_code_freeze"]:
+        try:
+            prev_cf = date.fromisoformat(indexed_context["previous_release_code_freeze"])
+            cycle_start_date = (prev_cf + timedelta(days=14)).isoformat()
+            log(f"Cycle start date from prev CF + 14d fallback: {cycle_start_date}", node="indexer")
+        except (ValueError, TypeError):
+            log("Could not compute cycle_start_date from previous_release_code_freeze", node="indexer", level="WARNING")
+    else:
+        log("No cycle_start_date available: no schedule dates and no previous CF", node="indexer", level="WARNING")
+    indexed_context["cycle_start_date"] = cycle_start_date
 
     # Log summary
     release = release_version if release_version else "unknown"

--- a/services/shutdown.py
+++ b/services/shutdown.py
@@ -1,0 +1,21 @@
+"""Shared shutdown coordination via threading.Event."""
+
+import threading
+
+_shutdown_event = threading.Event()
+
+
+def is_shutdown_requested() -> bool:
+    return _shutdown_event.is_set()
+
+
+def request_shutdown() -> None:
+    _shutdown_event.set()
+
+
+def wait_for_shutdown(timeout: float) -> bool:
+    """Block until shutdown is requested or timeout expires.
+
+    Returns True if shutdown was requested, False on timeout.
+    """
+    return _shutdown_event.wait(timeout=timeout)


### PR DESCRIPTION
## Summary

Filter stale and irrelevant PRs from VEP board/dashboard display:

- **Backport filtering**: base_ref checks across all layers to exclude
  PRs targeting release branches
- **Cycle start date filtering**: exclude merged impl and proposal PRs
  that predate the current release cycle (uses first schedule date from
  sig-release, fallback to prev CF + 14d)
- **Unenriched PR handling**: drop board-sourced PRs not found in prs_index
- Per-cycle YAML snapshots, SIGTERM graceful shutdown
- Fix string format crash in fetch_veps VEP number fallback

## Validation

Full Zeus cycle validated:
- [Before snapshot](https://pastebin.com/r65PgMKH) - [After snapshot](https://pastebin.com/7EgXwKJX)
- VEP 156: PR #16746 (impl, merged March 1) and PR #162 (proposal,
  merged Jan 14) correctly filtered from board - only post-cycle PRs #239, #261 shown
- VEP 109: backport PRs filtered, only #16675 remains
- Board updated (72/72 items), sheets/email/slack sent, no errors