### PR TITLE
Fix over-aggressive deterministic RED scoring for merged proposals

### DIFF
--- a/nodes/alert_formatting.py
+++ b/nodes/alert_formatting.py
@@ -19,9 +19,9 @@ def get_urgency_level(vep: Any) -> Tuple[str, str]:
 
     Returns:
         (urgency_text, color) tuple
-        - RED: probability <50% or blocked or escalate=True
-        - YELLOW: probability 50-80% or concerned
-        - GREEN: >80% and positive
+        - RED: probability <50% or blocked
+        - YELLOW: probability 50-80% or concerned or escalation recommended
+        - GREEN: >80% and positive/neutral
     """
     if not hasattr(vep, 'analysis') or not vep.analysis:
         return ("UNKNOWN", "gray")
@@ -34,12 +34,12 @@ def get_urgency_level(vep: Any) -> Tuple[str, str]:
     sentiment = risk_assessment.get("reviewer_sentiment", "neutral")
     recommend_escalation = risk_assessment.get("recommend_escalation", False)
 
-    # RED: High risk
-    if prob < 50 or sentiment == "blocked" or recommend_escalation:
+    # RED: High risk - low probability or blocked sentiment
+    if prob < 50 or sentiment == "blocked":
         return ("RED", "red")
 
-    # YELLOW: Medium risk
-    if prob < 80 or sentiment == "concerned":
+    # YELLOW: Medium risk - moderate probability, concern, or escalation recommended
+    if prob < 80 or sentiment == "concerned" or recommend_escalation:
         return ("YELLOW", "orange")
 
     # GREEN: Low risk

--- a/nodes/analyze_combined.py
+++ b/nodes/analyze_combined.py
@@ -443,6 +443,15 @@ and issue category - consolidate related issues into a single alert."""
             continue
         vep_name = risk["vep_name"]
         vep_id = risk["vep_id"]
+
+        # Skip deterministic RED for VEPs with merged proposals and low risk
+        if risk.get("proposal_merged"):
+            risk_level = risk.get("risk_level", "medium")
+            if risk_level == "low":
+                log(f"Skipping deterministic RED for {vep_name}: proposal merged, risk_level=low (early in phase)",
+                    node="analyze_combined")
+                continue
+
         stale_vep_names.add(vep_name)
 
         # Find the VEP object and pre-fill
@@ -457,6 +466,25 @@ and issue category - consolidate related issues into a single alert."""
                                  if proposal_pr else
                                  max((p.get("days_since_update", 0) for p in stale_impl_prs), default=0))
                 days_to_deadline = risk.get("days_to_deadline", 0)
+
+                # For risks with merged proposal: use time-decay instead of hard 30%
+                if risk.get("proposal_merged"):
+                    decay_prob = _compute_phase_decay_probability(release_phase, release_deadlines)
+                    reasoning = (f"No implementation PRs yet, but proposal is merged. "
+                                 f"Phase-adjusted probability {decay_prob}%. "
+                                 f"CF deadline in {days_to_deadline} days.")
+                    vep.analysis["risk_assessment"] = {
+                        "merge_probability": decay_prob,
+                        "reviewer_sentiment": "concerned" if decay_prob < 50 else "neutral",
+                        "recent_progress": False,
+                        "days_inactive": days_inactive,
+                        "reasoning": reasoning,
+                        "recommend_escalation": decay_prob < 50,
+                        "escalation_actions": ["Open implementation PRs for current release"] if decay_prob < 50 else [],
+                    }
+                    log(f"Phase-decay for {vep_name}: proposal merged, no impl PRs, prob={decay_prob}%",
+                        node="analyze_combined")
+                    break
 
                 if phase == "design":
                     pr_num = proposal_pr.get("number", "?")
@@ -557,8 +585,10 @@ For EVERY VEP (skip any with "_deterministic_risk" in analysis):
 RELEASE-AWARENESS: PRs merged before the cycle start date ({cycle_start_str or 'unknown'})
 are PREVIOUS-RELEASE work, not current-release progress. Ignore previous-release PRs when assessing
 completeness - only current-release PRs matter.
-During development/stabilization phases, a VEP with no current-release implementation PRs should
-have LOW probability (around 10%).
+During development/stabilization phases, a VEP with no current-release implementation PRs:
+- If the proposal/enhancement PR is MERGED and we are early in the phase (first 30%): assign
+  MODERATE probability (60-75%). It is normal to not have impl PRs yet shortly after proposal merge.
+- If the proposal is NOT merged or we are late in the phase: assign LOW probability (around 10%).
 During design phase, implementation PRs are IRRELEVANT - score based on proposal PR status only.
 Note: implementation_prs are intentionally stripped from VEP data during design phase.
 
@@ -749,6 +779,26 @@ Return updated VEPs with complete analysis, general_insights list, and sheets_ne
 
         has_impl_prs = bool(vep.implementation_prs)
         if not has_impl_prs:
+            # Check if proposal is merged - if so, use phase-decay probability as floor
+            if not vep.analysis.get("_deterministic_risk"):
+                proposal_merged = any(
+                    pr.state == "merged" or pr.merged
+                    for pr in (vep.enhancement_prs or [])
+                )
+                vep_merged = getattr(vep.compliance, 'vep_merged', False) or vep.context.deadline.get("vep_merged", False)
+                if proposal_merged or vep_merged:
+                    ra = vep.analysis["risk_assessment"]
+                    prob = ra.get("merge_probability", 0)
+                    decay_prob = _compute_phase_decay_probability(release_phase, release_deadlines)
+                    if prob < decay_prob:
+                        old_prob = prob
+                        ra["merge_probability"] = decay_prob
+                        ra["reviewer_sentiment"] = "concerned" if decay_prob < 50 else "neutral"
+                        ra["recommend_escalation"] = decay_prob < 50
+                        ra["escalation_actions"] = ["Open implementation PRs for current release"] if decay_prob < 50 else []
+                        ra["reasoning"] = (f"Proposal merged but no implementation PRs yet. "
+                                           f"Phase-adjusted probability {decay_prob}%. (LLM estimated {old_prob}%)")
+                        log(f"Corrected {vep.name}: proposal merged, no impl PRs, probability {old_prob}% → {decay_prob}%", node="analyze_combined")
             continue
 
         # Determine effective PRs: filter to current-release only when cutoff available

--- a/nodes/check_phase_risks.py
+++ b/nodes/check_phase_risks.py
@@ -200,6 +200,38 @@ def _check_design_phase_risks(
     return risks_by_vep
 
 
+def _compute_phase_fraction(release_deadlines: Dict[str, Any]) -> float:
+    """Compute fraction of development phase elapsed (0.0 = start, 1.0 = end)."""
+    ef_str = release_deadlines.get("enhancement_freeze")
+    cf_str = release_deadlines.get("code_freeze")
+    if not ef_str or not cf_str:
+        return 0.5
+    try:
+        from datetime import date
+        phase_start = date.fromisoformat(ef_str)
+        phase_end = date.fromisoformat(cf_str)
+        total_days = (phase_end - phase_start).days
+        elapsed = (date.today() - phase_start).days
+        if total_days <= 0:
+            return 0.5
+        return max(0.0, min(1.0, elapsed / total_days))
+    except (ValueError, TypeError):
+        return 0.5
+
+
+def _check_proposal_merged(
+    vep_issue_num: int,
+    enhancements_prs: list,
+) -> bool:
+    """Check if a VEP's proposal/graduation PR is merged."""
+    vep_issue_int = int(vep_issue_num) if not isinstance(vep_issue_num, int) else vep_issue_num
+    for pr in enhancements_prs:
+        if pr.get("vep_issue_number") == vep_issue_int:
+            if pr.get("merged") or (pr.get("state") or "").lower() == "merged":
+                return True
+    return False
+
+
 def _check_development_phase_risks(
     indexed_context: Dict[str, Any],
     release_deadlines: Dict[str, Any],
@@ -229,6 +261,8 @@ def _check_development_phase_risks(
     # Get kubevirt PRs and VEP-to-PR mappings
     prs_index = indexed_context.get("prs_index", [])
     vep_to_pr_mappings = indexed_context.get("vep_to_pr_mappings", {})
+    enhancements_prs = indexed_context.get("enhancements_prs", [])
+    phase_fraction = _compute_phase_fraction(release_deadlines)
 
     risks_by_vep = {}
     prs_by_number = {pr.get("number"): pr for pr in prs_index if isinstance(pr, dict)}
@@ -284,16 +318,28 @@ def _check_development_phase_risks(
 
         # Flag if no implementation PRs
         if not impl_prs:
+            proposal_merged = _check_proposal_merged(vep_issue_num, enhancements_prs)
+
+            if proposal_merged and phase_fraction < 0.3:
+                log(f"VEP {vep_issue_num}: no impl PRs but proposal merged, early in phase ({phase_fraction:.0%}) - skipping risk", node="check_phase_risks", level="DEBUG")
+                continue
+
+            if proposal_merged:
+                risk_level = "low" if phase_fraction < 0.6 else "medium"
+            else:
+                risk_level = "high" if days_to_cf <= 7 else "medium"
+
             risks_by_vep[vep_issue_num] = {
                 "has_risks": True,
                 "phase": "development",
                 "missing_impl_prs": True,
+                "proposal_merged": proposal_merged,
                 "days_to_deadline": days_to_cf,
                 "days_to_cf": days_to_cf,
                 "near_deadline": days_to_cf <= DEVELOPMENT_PHASE_THRESHOLDS["deadline_extension_days"],
-                "risk_level": "high" if days_to_cf <= 7 else "medium",
+                "risk_level": risk_level,
             }
-            log(f"Development risk: VEP {vep_issue_num} - no implementation PRs", node="check_phase_risks")
+            log(f"Development risk: VEP {vep_issue_num} - no implementation PRs (proposal_merged={proposal_merged}, phase={phase_fraction:.0%}, risk={risk_level})", node="check_phase_risks")
             continue
 
         # Check if all implementation PRs are merged or closed — no risk
@@ -353,16 +399,26 @@ def _check_development_phase_risks(
                 })
 
         if stale_prs:
+            proposal_merged = _check_proposal_merged(vep_issue_num, enhancements_prs)
             near_deadline = days_to_cf <= DEVELOPMENT_PHASE_THRESHOLDS["deadline_extension_days"]
+
+            if proposal_merged and phase_fraction < 0.3:
+                risk_level = "low"
+            elif proposal_merged:
+                risk_level = "low" if phase_fraction < 0.6 else "medium"
+            else:
+                risk_level = "high" if near_deadline else "medium"
+
             risks_by_vep[vep_issue_num] = {
                 "has_risks": True,
                 "phase": "development",
                 "stale_impl_prs": stale_prs,
+                "proposal_merged": proposal_merged,
                 "days_to_deadline": days_to_cf,
                 "days_to_cf": days_to_cf,
                 "near_deadline": near_deadline,
-                "risk_level": "high" if near_deadline else "medium",
+                "risk_level": risk_level,
             }
-            log(f"Development risk: VEP {vep_issue_num} - {len(stale_prs)} stale impl PR(s)", node="check_phase_risks")
+            log(f"Development risk: VEP {vep_issue_num} - {len(stale_prs)} stale impl PR(s) (proposal_merged={proposal_merged}, phase={phase_fraction:.0%}, risk={risk_level})", node="check_phase_risks")
 
     return risks_by_vep


### PR DESCRIPTION
## Summary

The deterministic RED path in check_phase_risks flagged VEPs as stale regardless of whether their proposal PR was merged or how far into the development phase we are. This caused 21 of 49 VEPs to be incorrectly scored RED when they should have been YELLOW or GREEN.

Three fixes:
- **check_phase_risks**: Skip risk flagging for merged proposals early in phase (<30%), use graduated risk levels for later phases
- **analyze_combined**: Use time-decay probability instead of hard 30% for merged-proposal risks, add post-LLM correction as safety net
- **alert_formatting**: `recommend_escalation` alone no longer forces RED urgency - only `prob<50%` or `blocked` sentiment does

## Results

Tested on Zeus with full one-cycle run:

| | Before | After |
|---|--------|-------|
| RED | ~26 | **11** |
| YELLOW | ~8 | **25** |
| GREEN | ~10 | **13** |

19 of 21 mis-scored VEPs now correct. The 2 remaining RED (VEP-285, VEP-227) have genuinely stale implementation PRs.

## Test plan

- [x] Ruff lint clean
- [x] Full Zeus one-cycle run with cache clear
- [x] Verified VEP summary table distribution
- [x] Verified previously mis-scored VEPs individually