### PR TITLE
Add v1.10 board mapping, fix container build/deploy, lower run interval to 12h

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ Alerts are color-coded by severity (Critical=red, High=orange, Medium=yellow, Lo
 
 ### Scheduling
 
-All operations run every 4 hours on round hours by default. Configure intervals in `config.py` (`FETCH_VEPS_INTERVAL_SECONDS`, etc.). Use `--immediate-start` to skip waiting for round hour.
+All operations run every 12 hours on round hours by default. Configure intervals in `config.py` (`FETCH_VEPS_INTERVAL_SECONDS`, etc.). Use `--immediate-start` to skip waiting for round hour.
 
 ### Caching
 

--- a/config/config.py
+++ b/config/config.py
@@ -16,6 +16,7 @@ VERSION_PROJECT_BOARDS: Dict[str, int] = {
     "1.7": 18,
     "1.8": 19,
     "1.9": 21,
+    "1.10": 22,
 }
 
 # Model configuration per node type

--- a/config/config.py
+++ b/config/config.py
@@ -48,7 +48,7 @@ EMAIL_RECIPIENTS: List[str] = [
 
 # Agent operation interval (in seconds)
 # After each fetch, the full pipeline runs: fetch_veps -> run_monitoring -> analyze_combined -> update_sheets -> alert_summary
-FETCH_VEPS_INTERVAL_SECONDS: int = 4 * 60 * 60  # 4 hours
+FETCH_VEPS_INTERVAL_SECONDS: int = 12 * 60 * 60  # 12 hours
 
 # LLM rate limit retry configuration
 LLM_MAX_RETRIES: int = 3

--- a/container/Containerfile
+++ b/container/Containerfile
@@ -2,7 +2,7 @@ FROM python:3.11-slim
 
 # Install Node.js (required for npx and MCP servers) and curl
 RUN apt-get update && apt-get install -y curl && \
-    curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+    curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
     apt-get install -y nodejs && \
     npm install -g npm@latest && \
     apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,12 @@
+Exit code: 0
+
+--- stdout ---
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+
+CONTAINER_NAME="vagent1"
+
+podman stop "$CONTAINER_NAME" 2>/dev/null || true
+podman rm "$CONTAINER_NAME" 2>/dev/null || true
+exec ./scripts/run-latest-agent.sh --detach --container-name "$CONTAINER_NAME" --immediate-start "$@"

--- a/scripts/run-latest-agent.sh
+++ b/scripts/run-latest-agent.sh
@@ -28,9 +28,31 @@ if [ -f "$PROJECT_ROOT/SLACK_WEBHOOK_URL" ]; then
     CMD_ARGS+=(--slack-webhook-url /workspace/SLACK_WEBHOOK_URL)
 fi
 
+# Parse deploy-specific flags (--detach, --container-name) out of the
+# argument list before the rest are forwarded to the agent inside the container
+DETACH_MODE=false
+CONTAINER_NAME=""
+FORWARD_ARGS=()
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --detach)
+            DETACH_MODE=true
+            shift
+            ;;
+        --container-name)
+            CONTAINER_NAME="$2"
+            shift 2
+            ;;
+        *)
+            FORWARD_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
 # Check if --sheet-id is already in arguments (user override)
 SHEET_ID_IN_ARGS=false
-for arg in "$@"; do
+for arg in "${FORWARD_ARGS[@]}"; do
     if [[ "$arg" == --sheet-id* ]]; then
         SHEET_ID_IN_ARGS=true
         break
@@ -42,17 +64,22 @@ if [ "$SHEET_ID_IN_ARGS" = false ]; then
     CMD_ARGS+=(--sheet-id "$DEFAULT_SHEET_ID")
 fi
 
-# Pass through any additional arguments/flags
-if [ $# -gt 0 ]; then
-    for arg in "$@"; do
-        CMD_ARGS+=("$arg")
-    done
+# Pass through any remaining arguments/flags
+CMD_ARGS+=("${FORWARD_ARGS[@]}")
+
+# Build podman run flags - detached/named for production deploys, foreground otherwise
+PODMAN_FLAGS=(--rm --pull=newer)
+if [ "$DETACH_MODE" = true ]; then
+    PODMAN_FLAGS+=(--detach --log-driver=journald)
+fi
+if [ -n "$CONTAINER_NAME" ]; then
+    PODMAN_FLAGS+=(--name "$CONTAINER_NAME")
 fi
 
 # Execute the command
 # Set PYTHONUNBUFFERED=1 to ensure logs are flushed immediately (important for real-time log viewing)
 # Mount workspace as read-only, but cache directory as read-write for persistence
-podman run --rm --pull=newer \
+podman run "${PODMAN_FLAGS[@]}" \
     -e PYTHONUNBUFFERED=1 \
     --network=host \
     -v "$PROJECT_ROOT:/workspace:ro" \


### PR DESCRIPTION
## Summary
- Add GitHub Project board 22 mapping for kubevirt v1.10
- Fix container build (Node 20 -> 22, npm engine mismatch)
- Add deploy.sh and detached/named container support in run-latest-agent.sh
- Lower agent run interval from 4h to 12h