### PR TITLE
WS1: Cycle scoping & reference-based PR-to-VEP attribution

### DIFF
--- a/main.py
+++ b/main.py
@@ -342,6 +342,11 @@ def parse_args():
         action="store_true",
         help="Clear all history and caches (state_cache.json, index_cache.json, history snapshots, alert persistence) and exit. Useful for fresh starts."
     )
+    parser.add_argument(
+        "--attribution-dump",
+        action="store_true",
+        help="Dump per-VEP Proposal/Impl PR attribution as JSON (indexer + deterministic attribution only, no LLM, no board writes) and exit. For validating PR->VEP attribution."
+    )
     return parser.parse_args()
 
 
@@ -463,7 +468,50 @@ def main():
 
     # Set up credentials from CLI args
     setup_credentials(args)
-    
+
+    # Handle --attribution-dump: deterministic PR->VEP attribution only (indexer +
+    # attribution, no LLM, no board writes), printed as JSON, then exit. For
+    # validating attribution against the live board without running the full graph.
+    if args.attribution_dump:
+        from nodes.alert_formatting import build_vep_summary_table
+        from nodes.fetch_veps import fetch_veps_node
+        from services.indexer import create_indexed_context
+        dump_cache_minutes = 0 if args.no_index_cache else args.index_cache_minutes
+        veps = fetch_veps_node({"index_cache_minutes": dump_cache_minutes}).get("veps", [])
+        ctx = create_indexed_context(cache_max_age_minutes=dump_cache_minutes)
+        rows = build_vep_summary_table(veps, indexed_context=ctx)
+        dump = {
+            "current_release": ctx.get("current_release"),
+            "cycle_start_date": ctx.get("cycle_start_date"),
+            "previous_release_code_freeze": ctx.get("previous_release_code_freeze"),
+            "vep_count": len(rows),
+            "veps": [
+                {
+                    "vep": r["vep_number"],
+                    "name": r["vep_name"],
+                    "proposal_prs": sorted(p["number"] for p in r["proposal_prs"]),
+                    "impl_prs": sorted(p["number"] for p in r["impl_prs"]),
+                }
+                for r in sorted(rows, key=lambda r: r["vep_number"])
+            ],
+        }
+        # Also persist to a file in the rw-mounted output/ dir so the dump can
+        # be pulled cleanly. Scraping journald truncates this large JSON.
+        # main.py sits on a read-only mount, but output/ is mounted read-write.
+        dump_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "output")
+        try:
+            os.makedirs(dump_dir, exist_ok=True)
+            dump_path = os.path.join(dump_dir, "attribution_dump.json")
+            with open(dump_path, "w") as _f:
+                json.dump(dump, _f, indent=2)
+            log(f"Wrote attribution dump to {dump_path}", node="main")
+        except OSError as e:
+            log(f"Could not write attribution dump file: {e}", node="main", level="WARNING")
+        print("ATTRIBUTION_DUMP_JSON_START")
+        print(json.dumps(dump, indent=2))
+        print("ATTRIBUTION_DUMP_JSON_END")
+        return
+
     # Handle index cache flags
     index_cache_minutes = 0 if args.no_index_cache else args.index_cache_minutes
     if args.no_index_cache:

--- a/nodes/alert_formatting.py
+++ b/nodes/alert_formatting.py
@@ -8,9 +8,11 @@ Provides utilities to build per-VEP summary tables with:
 """
 
 import re
+from collections.abc import Callable
 from datetime import UTC, date, datetime
 from typing import Any
 
+from services.attribution import parse_enumerated_impl_prs, resolve_impl_owner
 from services.indexer import create_indexed_context
 from services.utils import log
 
@@ -47,12 +49,20 @@ def get_urgency_level(vep: Any) -> tuple[str, str]:
     return ("GREEN", "green")
 
 
-def build_vep_summary_table(veps: list[Any], indexed_context: dict[str, Any] | None = None) -> list[dict[str, Any]]:
+def build_vep_summary_table(
+    veps: list[Any],
+    indexed_context: dict[str, Any] | None = None,
+    pr_metadata_fetcher: Callable[[list[int]], dict[int, dict[str, Any]]] | None = None,
+) -> list[dict[str, Any]]:
     """Build per-VEP summary table data.
 
     Args:
         veps: List of VEPInfo objects
         indexed_context: Optional indexed context (will be fetched if not provided)
+        pr_metadata_fetcher: Optional override for fetching real metadata (state,
+            merged_at, base_ref) of impl PRs enumerated in a tracking issue but
+            absent from prs_index ("widened" PRs). Defaults to
+            services.indexer.fetch_pr_metadata_by_number. Injectable for tests.
 
     Returns:
         List of dicts with table row data:
@@ -73,12 +83,12 @@ def build_vep_summary_table(veps: list[Any], indexed_context: dict[str, Any] | N
 
     enhancements_prs = indexed_context.get("enhancements_prs", [])
     enhancements_by_number = {pr.get("number"): pr for pr in enhancements_prs}
-    board_veps = indexed_context.get("board_veps", {})
     issues_index = indexed_context.get("issues_index", [])
+    kubevirt_prs = indexed_context.get("prs_index", [])
 
     # Build base_ref lookup from prs_index for filtering backport impl PRs
     prs_by_number = {}
-    for pr in indexed_context.get("prs_index", []):
+    for pr in kubevirt_prs:
         if isinstance(pr, dict) and pr.get("number"):
             prs_by_number[pr["number"]] = pr
 
@@ -89,48 +99,107 @@ def build_vep_summary_table(veps: list[Any], indexed_context: dict[str, Any] | N
         if issue_num:
             issues_by_number[issue_num] = issue
 
+    # ---- Precompute implementation-PR ownership (one PR -> one VEP) ----
+    # Attribution is reference-based, never title-based. Two signals per PR:
+    # the PR's self-declared tracking issue and the tracking issue's own
+    # enumerated PR list; resolve_impl_owner reconciles them (a reciprocated
+    # link wins on conflict). Computed once so each PR lands on a single VEP.
+    in_scope_issues = {v.tracking_issue_id for v in veps}
+    enumerated_by_pr: dict[int, set[int]] = {}
+    for vep in veps:
+        issue = issues_by_number.get(vep.tracking_issue_id)
+        body = (issue.get("body") or issue.get("body_preview") or "") if issue else ""
+        for pr_num in parse_enumerated_impl_prs(body):
+            enumerated_by_pr.setdefault(pr_num, set()).add(vep.tracking_issue_id)
+
+    impl_by_vep: dict[int, list[dict[str, Any]]] = {}
+    for pr in kubevirt_prs:
+        if not isinstance(pr, dict):
+            continue
+        pr_num = pr.get("number")
+        if not pr_num:
+            continue
+        pr_url = pr.get("url") or pr.get("html_url") or f"https://github.com/kubevirt/kubevirt/pull/{pr_num}"
+        if "enhancements" in pr_url:
+            continue  # proposal PR, never an implementation PR
+        self_ref = pr.get("vep_issue_number")
+        if self_ref not in in_scope_issues:
+            self_ref = None
+        enumerating = enumerated_by_pr.get(pr_num, set()) & in_scope_issues
+        owner, conflict = resolve_impl_owner(self_ref, enumerating)
+        if owner is None:
+            continue
+        if conflict:
+            log(
+                f"Impl PR #{pr_num}: attribution conflict "
+                f"(self-ref {pr.get('vep_issue_number')}, enumerated by {sorted(enumerating)}) "
+                f"-> assigned VEP #{owner}",
+                node="alert_formatting",
+            )
+        impl_by_vep.setdefault(owner, []).append({
+            "number": pr_num,
+            "url": pr_url,
+            "_state": pr.get("state"),
+            "_merged_at": pr.get("merged_at"),
+        })
+
+    # Widen: attribute issue-enumerated impl PRs that never appeared in
+    # prs_index (e.g. old PRs beyond the ~1200-PR fetch window). They carry no
+    # self-ref, so resolve_impl_owner keys purely on the enumerating issue
+    # (unambiguous single issue -> that VEP). Real metadata is fetched below so
+    # they still go through the same cycle-scoping filters as indexed PRs.
+    already_placed = {p["number"] for prs in impl_by_vep.values() for p in prs}
+    widened: list[tuple[int, int]] = []  # (pr_num, owner)
+    for pr_num, enumerating_issues in enumerated_by_pr.items():
+        if pr_num in already_placed:
+            continue
+        enumerating = enumerating_issues & in_scope_issues
+        owner, conflict = resolve_impl_owner(None, enumerating)
+        if owner is None:
+            continue
+        if conflict:
+            log(
+                f"Impl PR #{pr_num}: enumerated by multiple in-scope issues "
+                f"{sorted(enumerating)} and absent from prs_index -> left unlinked",
+                node="alert_formatting",
+            )
+            continue
+        widened.append((pr_num, owner))
+
+    if widened:
+        fetcher = pr_metadata_fetcher
+        if fetcher is None:
+            from services.indexer import fetch_pr_metadata_by_number
+            fetcher = fetch_pr_metadata_by_number
+        meta = fetcher(sorted({pr_num for pr_num, _ in widened}))
+        for pr_num, owner in widened:
+            m = meta.get(pr_num, {})
+            if not m:
+                log(
+                    f"Impl PR #{pr_num}: could not fetch metadata for widened PR "
+                    f"-> including without cycle-scoping verification",
+                    node="alert_formatting",
+                    level="WARNING",
+                )
+            impl_by_vep.setdefault(owner, []).append({
+                "number": pr_num,
+                "url": f"https://github.com/kubevirt/kubevirt/pull/{pr_num}",
+                "_state": m.get("state"),
+                "_merged_at": m.get("merged_at"),
+                "_base_ref": m.get("base_ref"),
+            })
+
     table_rows = []
 
     for vep in veps:
-        # Get proposal PRs for this VEP from multiple sources
-        proposal_pr_numbers = set()
-
-        # Extract VEP number from VEP name (e.g., "vep-0016" -> 16)
-        vep_number = None
-        vep_match = re.search(r'vep-?(\d+)', vep.name, re.IGNORECASE)
-        if vep_match:
-            vep_number = int(vep_match.group(1))
-
-        # Source 1: Extract from tracking issue body
-        issue = issues_by_number.get(vep.tracking_issue_id)
-        if issue:
-            body = issue.get("body", "") or issue.get("body_preview", "")
-            if body:
-                # Extract enhancements PR URLs from issue body
-                pr_url_pattern = re.compile(r'github\.com/kubevirt/enhancements/pull/(\d+)')
-                for match in pr_url_pattern.finditer(body):
-                    proposal_pr_numbers.add(int(match.group(1)))
-
-        # Source 2: Match PRs by VEP number in PR title (MOST RELIABLE)
-        # Many proposal PRs have titles like "VEP 16: Title" or "vep-0016: Title"
-        if vep_number:
-            for pr in enhancements_prs:
-                pr_title = pr.get("title", "")
-                # Look for VEP number in PR title
-                title_vep_patterns = [
-                    rf'VEP[- ]?{vep_number}[\s:]',  # "VEP 16:" or "VEP-16:"
-                    rf'vep[- ]?{vep_number:04d}[\s:]',  # "vep-0016:"
-                    rf'vep[- ]?{vep_number}[\s:]',  # "vep-16:" or "vep 16:"
-                ]
-                for pattern in title_vep_patterns:
-                    if re.search(pattern, pr_title, re.IGNORECASE):
-                        proposal_pr_numbers.add(pr.get("number"))
-                        break
-
-        # Source 3: Match from enhancements_prs by vep_issue_number (fallback)
-        for pr in enhancements_prs:
-            if pr.get("vep_issue_number") == vep.tracking_issue_id:
-                proposal_pr_numbers.add(pr.get("number"))
+        # Proposal PRs: attribute strictly by the PR's own tracking-issue
+        # reference (one PR -> one VEP). vep_issue_number is set at index time
+        # by the hardened extractor; title / issue-body scanning is not used.
+        proposal_pr_numbers = {
+            pr.get("number")
+            for pr in enhancements_prs
+            if pr.get("vep_issue_number") == vep.tracking_issue_id and pr.get("number")
+        }
 
         # Build proposal PRs list with URLs and state/merged_at for filtering
         proposal_prs = []
@@ -174,114 +243,9 @@ def build_vep_summary_table(veps: list[Any], indexed_context: dict[str, Any] | N
         # Strip internal fields from proposal PRs
         proposal_prs = [{"number": p["number"], "url": p["url"]} for p in proposal_prs]
 
-        # Get implementation PRs from multiple sources
-        # IMPORTANT: Implementation PRs can NEVER be from kubevirt/enhancements (those are proposal PRs)
-        impl_pr_numbers = set()
-        impl_prs = []
-
-        # Source 1: Use vep.implementation_prs if available (from board data)
-        if vep.implementation_prs:
-            for pr in vep.implementation_prs:
-                # Skip enhancements PRs - they are proposal PRs, not implementation PRs
-                if "enhancements" in (pr.url or ""):
-                    continue
-                if pr.number not in impl_pr_numbers:
-                    impl_pr_numbers.add(pr.number)
-                    impl_prs.append({
-                        "number": pr.number,
-                        "url": pr.url,
-                        "_state": pr.state,
-                        "_merged_at": pr.merged_at,
-                    })
-        else:
-            # Fall back to board_veps (in case VEPInfo doesn't have them)
-            board_vep = board_veps.get(vep.tracking_issue_id, {})
-            board_impl_prs = board_vep.get("impl_prs", [])
-            for pr in board_impl_prs:
-                pr_num = pr.get("number")
-                pr_url = pr.get("url", "")
-                # Skip enhancements PRs
-                if "enhancements" in pr_url:
-                    continue
-                if pr_num and pr_num not in impl_pr_numbers:
-                    impl_pr_numbers.add(pr_num)
-                    impl_prs.append({
-                        "number": pr_num,
-                        "url": pr_url,
-                        "_state": pr.get("state"),
-                        "_merged_at": pr.get("merged_at"),
-                    })
-
-        # Cross-check board-sourced impl PRs: skip if PR title names a different VEP
-        if vep_number and impl_prs:
-            title_vep_re = re.compile(r'vep[-\s#]?0*(\d+)', re.IGNORECASE)
-            filtered = []
-            for p in impl_prs:
-                pr_data = prs_by_number.get(p["number"])
-                if pr_data:
-                    pr_title = pr_data.get("title", "")
-                    tveps = title_vep_re.findall(pr_title)
-                    if tveps and str(vep_number) not in tveps:
-                        log(f"VEP {vep.name}: skipping board impl PR #{p['number']} "
-                            f"(title references VEP {','.join(tveps)}, not {vep_number})",
-                            node="alert_formatting")
-                        impl_pr_numbers.discard(p["number"])
-                        continue
-                filtered.append(p)
-            impl_prs = filtered
-
-        # Source 2: Match from kubevirt PRs by vep_issue_number
-        # (PRs that reference this VEP issue in their description)
-        kubevirt_prs = indexed_context.get("prs_index", [])
-        for pr in kubevirt_prs:
-            if pr.get("vep_issue_number") == vep.tracking_issue_id:
-                pr_num = pr.get("number")
-                pr_url = pr.get("url", f"https://github.com/kubevirt/kubevirt/pull/{pr_num}")
-                if "enhancements" in pr_url:
-                    continue
-                base_ref = pr.get("base_ref")
-                if base_ref and base_ref not in ("main", "master"):
-                    continue
-                if pr_num and pr_num not in impl_pr_numbers:
-                    impl_pr_numbers.add(pr_num)
-                    impl_prs.append({
-                        "number": pr_num,
-                        "url": pr_url,
-                        "_state": pr.get("state"),
-                        "_merged_at": pr.get("merged_at"),
-                    })
-
-        # Source 3: Match from vep_to_pr_mappings (PRs with "vep-62" etc. in title/body)
-        # Skip PRs whose title clearly indicates a different VEP (body-only mentions
-        # are often references/dependencies, not implementations).
-        vep_to_pr_mappings = indexed_context.get("vep_to_pr_mappings", {})
-        vep_key = str(vep.tracking_issue_id)
-        title_vep_pattern = re.compile(r'vep[-\s#]?0*(\d+)', re.IGNORECASE)
-        for pr in vep_to_pr_mappings.get(vep_key, []):
-            pr_num = pr.get("number")
-            pr_url = pr.get("url", f"https://github.com/kubevirt/kubevirt/pull/{pr_num}")
-            if "enhancements" in pr_url:
-                continue
-            base_ref = pr.get("base_ref")
-            if not base_ref and pr_num:
-                idx = prs_by_number.get(pr_num)
-                if idx:
-                    base_ref = idx.get("base_ref")
-            if base_ref and base_ref not in ("main", "master"):
-                continue
-            # Skip if PR title references a different VEP number
-            pr_title = pr.get("title", "")
-            title_vep_matches = title_vep_pattern.findall(pr_title)
-            if title_vep_matches and vep_key not in title_vep_matches:
-                continue
-            if pr_num and pr_num not in impl_pr_numbers:
-                impl_pr_numbers.add(pr_num)
-                impl_prs.append({
-                    "number": pr_num,
-                    "url": pr_url,
-                    "_state": pr.get("state"),
-                    "_merged_at": pr.get("merged_at"),
-                })
+        # Implementation PRs: from the precomputed one-PR-one-VEP ownership map.
+        impl_prs = [dict(p) for p in impl_by_vep.get(vep.tracking_issue_id, [])]
+        impl_pr_numbers = {p["number"] for p in impl_prs}
 
         # Exclude impl PRs that are actually from the enhancements repo (proposal PRs)
         # Compare by URL since the same PR number can exist in both repos
@@ -316,10 +280,9 @@ def build_vep_summary_table(veps: list[Any], indexed_context: dict[str, Any] | N
         filtered = []
         for p in impl_prs:
             pr_index_data = prs_by_number.get(p["number"])
-            if pr_index_data:
-                base_ref = pr_index_data.get("base_ref")
-                if base_ref and base_ref not in ("main", "master"):
-                    continue
+            base_ref = (pr_index_data or {}).get("base_ref") or p.get("_base_ref")
+            if base_ref and base_ref not in ("main", "master"):
+                continue
             filtered.append(p)
         impl_prs = filtered
         removed = before_count - len(impl_prs)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest

--- a/services/attribution.py
+++ b/services/attribution.py
@@ -1,0 +1,149 @@
+"""Deterministic PR -> VEP attribution.
+
+Pure, side-effect-free helpers for mapping GitHub PRs to VEP tracking issues.
+Kept separate from services.indexer so the logic stays unit-testable without the
+network / MCP import cost that services.indexer carries.
+
+Attribution rules (WS1 redesign):
+- One PR -> at most one VEP, keyed on the VEP's tracking-issue number.
+- Proposal PRs (kubevirt/enhancements): attributed solely by the PR's own
+  explicit tracking-issue reference (see ``extract_tracking_issue``).
+- Impl PRs (kubevirt/kubevirt): a reciprocity model between the PR's
+  self-declared reference and the tracking issue's own enumerated PR list.
+  When only one side speaks it is trusted; on an unreciprocated conflict the
+  PR's own reference wins and the conflict is surfaced (see ``resolve_impl_owner``).
+- Title-based "VEP N" matching is NOT used for attribution: it truncates
+  sub-VEPs (e.g. "VEP 25.1" -> 25) and collides siblings onto one number.
+"""
+
+import re
+
+# Literal placeholder left in unfilled PR templates - never a real reference.
+PLACEHOLDER_REF = "<vep_tracking_issue_number>"
+
+
+def _strip_markdown(text: str) -> str:
+    """Drop markdown emphasis / backtick chars that break keyword regexes.
+
+    Real-world PR bodies write "**Tracking issue**: ..." - the surrounding
+    asterisks otherwise sit between the keyword and its value and defeat the
+    keyword patterns below.
+    """
+    return re.sub(r"[*`]", "", text or "")
+
+
+def extract_tracking_issue(title: str, body: str) -> int | None:
+    """Return the enhancements tracking-issue number a PR references, or None.
+
+    Priority order (explicit declarations beat generic URL scanning):
+      1. Keyword declaration with inline number:  "Tracking issue: #399"
+      2. Keyword declaration with an issue URL:   "Tracking issue: .../issues/399"
+      3. "VEP N" in the title, whole numbers only (sub-VEPs "VEP N.M" skipped)
+      4. Generic close keyword:                   "closes #399"
+      5. Any enhancements issue URL (least reliable; this is the signal the
+         kubevirt approved-vep bot keys on for implementation PRs)
+
+    Markdown emphasis around keywords is tolerated; the literal
+    ``<vep_tracking_issue_number>`` template placeholder is rejected.
+    """
+    clean_title = _strip_markdown(title)
+    text = _strip_markdown(f"{title or ''} {body or ''}").replace(PLACEHOLDER_REF, " ")
+    if not text.strip():
+        return None
+
+    # 1. Keyword declaration with an inline number (most intentional).
+    for pattern in (
+        r"tracking\s+issue[\s:]+#?(\d+)",
+        r"vep\s+tracker[\s:]+#?(\d+)",
+        r"tracker[\s:]+#?(\d+)",
+        r"vep\s+issue[\s:]+#?(\d+)",
+    ):
+        match = re.search(pattern, text, re.IGNORECASE)
+        if match:
+            return int(match.group(1))
+
+    # 2. Keyword declaration followed by an issue URL.
+    match = re.search(
+        r"(?:tracking\s+issue|vep\s+tracker|tracker|vep\s+issue)"
+        r"[\s:]+\S*github\.com/kubevirt/enhancements/issues/(\d+)",
+        text,
+        re.IGNORECASE,
+    )
+    if match:
+        return int(match.group(1))
+
+    # 3. "VEP N" in the title - whole numbers only. The negative lookahead
+    #    skips sub-VEPs ("VEP 25.1"), which would otherwise truncate to 25 and
+    #    collide the sibling onto the parent VEP.
+    if clean_title:
+        match = re.search(r"VEP[- #]*0*(\d+)(?![.\d])", clean_title, re.IGNORECASE)
+        if match:
+            return int(match.group(1))
+
+    # 4. Generic close keywords.
+    match = re.search(r"(?:fixes|closes)[\s:]+#?(\d+)", text, re.IGNORECASE)
+    if match:
+        return int(match.group(1))
+
+    # 5. Any enhancements issue URL (footnotes/deps possible - last resort).
+    match = re.search(r"github\.com/kubevirt/enhancements/issues/(\d+)", text)
+    if match:
+        return int(match.group(1))
+
+    return None
+
+
+def parse_enumerated_impl_prs(issue_body: str) -> set[int]:
+    """Return kubevirt/kubevirt PR numbers a tracking issue body enumerates.
+
+    Matches full kubevirt/kubevirt pull URLs only (the form issues use to list
+    their implementation PRs). Enhancements PR URLs and bare ``#N`` references
+    are intentionally ignored: the former are proposal PRs, the latter are
+    ambiguous within an enhancements-repo issue.
+    """
+    if not issue_body:
+        return set()
+    text = _strip_markdown(issue_body)
+    return {int(m) for m in re.findall(r"kubevirt/kubevirt/pull/(\d+)", text)}
+
+
+def resolve_impl_owner(
+    self_ref: int | None,
+    enumerating_issues: set[int],
+) -> tuple[int | None, bool]:
+    """Resolve the single owning VEP tracking issue for one implementation PR.
+
+    Args:
+        self_ref: the in-scope tracking issue the PR declares in its body, or
+            None (caller passes None when the PR declares nothing in scope).
+        enumerating_issues: the in-scope tracking issues whose body enumerates
+            this PR.
+
+    Returns:
+        ``(owner_issue_number | None, conflict)``. ``owner`` is None when the PR
+        cannot be attributed (unlinked). ``conflict`` is True when the two
+        signals disagreed or were ambiguous and the result should be surfaced.
+
+    Reciprocity rules:
+      - self_ref reciprocated (self_ref enumerates the PR back) -> confident.
+      - self_ref set, no issue enumerates it -> trust the PR's own claim.
+      - self_ref set, competing issue(s) enumerate it instead -> trust the
+        PR's claim but flag the conflict.
+      - no self_ref, exactly one issue enumerates it -> that issue.
+      - no self_ref, several issues enumerate it -> unlinked + flag.
+    """
+    enum = set(enumerating_issues)
+    if self_ref is not None:
+        if self_ref in enum:
+            return self_ref, False          # reciprocated -> confident
+        if not enum:
+            return self_ref, False          # PR-only claim -> trust it
+        # self_ref not reciprocated, but other issue(s) enumerate this PR: an
+        # unreciprocated conflict. Trust the PR's own declaration (usually more
+        # reliable than an issue's hand-maintained list) but flag it for review.
+        return self_ref, True
+    if len(enum) == 1:
+        return next(iter(enum)), False      # issue-only, unambiguous
+    if len(enum) >= 2:
+        return None, True                   # several issues, no self-ref -> ambiguous
+    return None, False                      # unlinked

--- a/services/indexer.py
+++ b/services/indexer.py
@@ -2297,7 +2297,7 @@ def _load_cached_index(cache_file: Path, max_age_minutes: int = 60) -> dict[str,
             log(f"Cache expired (age: {age_minutes:.1f} minutes, max: {max_age_minutes} minutes), will regenerate", node="indexer")
             return None
     
-    except (json.JSONDecodeError, ValueError, KeyError) as e:
+    except (json.JSONDecodeError, ValueError, KeyError, TypeError) as e:
         log(f"Error reading cache file: {e}, will regenerate", node="indexer", level="WARNING")
         return None
 

--- a/services/indexer.py
+++ b/services/indexer.py
@@ -12,6 +12,7 @@ from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
+from services.attribution import extract_tracking_issue
 from services.mcp_factory import get_mcp_tools_by_name
 from services.utils import log
 
@@ -85,22 +86,122 @@ def _call_with_retry(tool_func, max_retries=3, delay=5, **kwargs):
     return None
 
 
+def _coerce_page_to_dict(result):
+    """Normalize one list_issues page result into a dict (or None).
+
+    Handles native dicts, JSON strings (possibly double-encoded), and bare
+    lists (wrapped as {"issues": [...]}).
+    """
+    if isinstance(result, dict):
+        return result
+    if isinstance(result, str):
+        try:
+            parsed = json.loads(result)
+        except (ValueError, TypeError):
+            return None
+        _d = 0
+        while isinstance(parsed, str) and _d < 3:
+            try:
+                parsed = json.loads(parsed)
+            except (ValueError, TypeError):
+                return None
+            _d += 1
+        if isinstance(parsed, dict):
+            return parsed
+        if isinstance(parsed, list):
+            return {"issues": parsed}
+    if isinstance(result, list):
+        return {"issues": result}
+    return None
+
+
 def _call_list_issues(list_issues_tool):
-    """Call list_issues with retry, handling different MCP tool argument styles."""
-    try:
-        return _call_with_retry(
-            list_issues_tool.func,
-            owner="kubevirt",
-            repo="enhancements",
-            state="all",
-            per_page=100,
+    """Call list_issues with cursor pagination, returning all issue dicts.
+
+    The MCP list_issues tool is GraphQL-backed: each call returns
+    {issues:[...], totalCount, pageInfo{hasNextPage, endCursor}} and caps a
+    page at ~30 issues. search_issues is unusable here (GitHub's search API
+    returns 403 rate-limit errors), so this is the sole reliable source and it
+    MUST follow the endCursor - otherwise only the newest ~30 of ~169 issues
+    are indexed, silently dropping older VEP tracking issues and the impl PRs
+    they enumerate. Returns a flat list of issue dicts. Falls back to the raw
+    single-page result if the response is not a readable page (e.g. an error
+    string), so the caller's existing error handling still applies.
+    """
+    all_issues = []
+    cursor = None
+    seen_cursors = set()
+    for _page in range(30):  # safety cap (~30 pages)
+        kwargs = {"owner": "kubevirt", "repo": "enhancements", "state": "all", "perPage": 100}
+        if cursor:
+            kwargs["after"] = cursor
+        try:
+            result = _call_with_retry(list_issues_tool.func, **kwargs)
+        except TypeError:
+            try:
+                result = _call_with_retry(
+                    list_issues_tool.func, repo="kubevirt/enhancements", state="all"
+                )
+            except TypeError:
+                result = _call_with_retry(
+                    list_issues_tool.func, owner="kubevirt", repo="enhancements", state="all"
+                )
+        page_dict = _coerce_page_to_dict(result)
+        if page_dict is None:
+            if not all_issues:
+                return result  # let the caller handle raw / error responses
+            break
+        page_issues = page_dict.get("issues")
+        if not isinstance(page_issues, list):
+            page_issues = page_dict.get("items") if isinstance(page_dict.get("items"), list) else []
+        all_issues.extend(page_issues)
+        page_info = page_dict.get("pageInfo") or {}
+        log(
+            f"list_issues page {_page + 1}: +{len(page_issues)} "
+            f"(total {len(all_issues)}/{page_dict.get('totalCount')}), "
+            f"hasNextPage={page_info.get('hasNextPage')}",
+            node="indexer",
         )
-    except TypeError:
-        return _call_with_retry(
-            list_issues_tool.func,
-            repo="kubevirt/enhancements",
-            state="all",
-        )
+        if not page_info.get("hasNextPage"):
+            break
+        cursor = page_info.get("endCursor")
+        if not cursor or cursor in seen_cursors:
+            break
+        seen_cursors.add(cursor)
+    return all_issues
+
+
+def _unwrap_issues_dict(d: dict) -> list | None:
+    """Extract a list of issue dicts from an MCP dict / content wrapper.
+
+    ``list_issues`` (the fallback used when ``search_issues`` is unavailable or
+    rate-limited) returns the issue array wrapped in a dict rather than as a
+    bare list. Without unwrapping, the response used to fall through to a
+    truncated ``raw_data`` blob and every issue body was lost. Known shapes:
+      - ``{"items": [...]}`` / ``{"issues": [...]}`` / ``{"data": [...]}`` -> the list
+      - ``{"content": "<json>"}`` or ``{"content": [{"text": "<json>"}]}`` -> parse, recurse
+      - a single issue object ``{"number": ...}`` -> ``[d]``
+    Returns the extracted list, or None if nothing issue-like is found.
+    """
+    for key in ("items", "issues", "data", "results"):
+        val = d.get(key)
+        if isinstance(val, list):
+            return val
+    content = d.get("content")
+    if isinstance(content, list):
+        content = "".join(c.get("text", "") for c in content if isinstance(c, dict))
+    if isinstance(content, str) and content.strip():
+        try:
+            parsed = json.loads(content)
+        except (ValueError, TypeError):
+            parsed = None
+        if isinstance(parsed, list):
+            return parsed
+        if isinstance(parsed, dict):
+            return _unwrap_issues_dict(parsed)
+    if "number" in d:  # a single issue object
+        return [d]
+    return None
 
 
 def _parse_version(version_str: str) -> tuple:
@@ -506,7 +607,7 @@ def index_enhancements_issues(days_back: int | None = 365) -> list[dict[str, Any
         if not search_issues_tool and not list_issues_tool:
             log(f"Could not find issues listing tool. Available tools: {[t.name for t in tools]}", node="indexer", level="WARNING")
             return []
-        
+
         try:
             # Use search_issues if available (more comprehensive)
             if search_issues_tool:
@@ -548,10 +649,18 @@ def index_enhancements_issues(days_back: int | None = 365) -> list[dict[str, Any
                         # Parse result
                         items = []
                         result_dict = None
-                        
+
                         if isinstance(result, str):
                             try:
-                                result_dict = json.loads(result)
+                                parsed = json.loads(result)
+                                _pd = 0
+                                while isinstance(parsed, str) and _pd < 3:
+                                    parsed = json.loads(parsed)
+                                    _pd += 1
+                                if isinstance(parsed, dict):
+                                    result_dict = parsed
+                                elif isinstance(parsed, list):
+                                    items = parsed
                             except (ValueError, TypeError):
                                 pass
                         elif isinstance(result, dict):
@@ -560,10 +669,21 @@ def index_enhancements_issues(days_back: int | None = 365) -> list[dict[str, Any
                             items = result
                         
                         if result_dict:
+                            # The GitHub MCP server returns search results in a
+                            # GraphQL-style {issues:[...], totalCount, pageInfo}
+                            # envelope, not the REST {items, total_count} shape.
+                            # Accept both, else every search returns 0 items and
+                            # issue bodies are lost (breaking PR enumeration).
                             if "items" in result_dict:
                                 items = result_dict["items"]
+                            elif "issues" in result_dict:
+                                items = result_dict["issues"]
+                            elif isinstance(result_dict.get("data"), list):
+                                items = result_dict["data"]
                             if "total_count" in result_dict:
                                 total_count = result_dict["total_count"]
+                            elif "totalCount" in result_dict:
+                                total_count = result_dict["totalCount"]
                             if result_dict.get("incomplete_results"):
                                 log(f"Warning: Search results for {state} issues may be incomplete", node="indexer", level="WARNING")
                         
@@ -658,6 +778,18 @@ def index_enhancements_issues(days_back: int | None = 365) -> list[dict[str, Any
                 issues_result = _call_list_issues(list_issues_tool)
             
             # Parse result
+            # Some MCP servers (the list_issues fallback) wrap the issue array
+            # in a dict; unwrap it to a bare list so the list branch below can
+            # extract bodies. Previously this fell through to a raw_data blob.
+            if isinstance(issues_result, dict):
+                unwrapped = _unwrap_issues_dict(issues_result)
+                log(
+                    f"issues_result is a dict (keys={list(issues_result.keys())}); "
+                    f"unwrapped to {len(unwrapped) if unwrapped is not None else 'None'} issues",
+                    node="indexer",
+                )
+                if unwrapped is not None:
+                    issues_result = unwrapped
             if isinstance(issues_result, str):
                 # Check if it's a rate limit error
                 if "rate limit" in issues_result.lower() or "rate_limit" in issues_result.lower():
@@ -673,6 +805,30 @@ def index_enhancements_issues(days_back: int | None = 365) -> list[dict[str, Any
                 # Try to parse as JSON
                 try:
                     parsed_issues = json.loads(issues_result)
+                    # MCP servers may double-encode the payload (a JSON string
+                    # whose value is itself JSON) and/or wrap the issue array in
+                    # a dict / content envelope. Unwrap nested strings first,
+                    # then dicts, logging the resolved shape for visibility so
+                    # issue bodies are actually populated (not lost to a blob).
+                    _unwrap_depth = 0
+                    while isinstance(parsed_issues, str) and _unwrap_depth < 3:
+                        try:
+                            parsed_issues = json.loads(parsed_issues)
+                        except (ValueError, TypeError):
+                            break
+                        _unwrap_depth += 1
+                    log(
+                        f"list_issues payload resolved to type={type(parsed_issues).__name__}"
+                        + (f" keys={list(parsed_issues.keys())} "
+                           f"totalCount={parsed_issues.get('totalCount')} "
+                           f"pageInfo={parsed_issues.get('pageInfo')}"
+                           if isinstance(parsed_issues, dict) else ""),
+                        node="indexer",
+                    )
+                    if isinstance(parsed_issues, dict):
+                        unwrapped = _unwrap_issues_dict(parsed_issues)
+                        if unwrapped is not None:
+                            parsed_issues = unwrapped
                     if isinstance(parsed_issues, list):
                         # Process as list
                         issues = []
@@ -772,8 +928,12 @@ def index_enhancements_issues(days_back: int | None = 365) -> list[dict[str, Any
                         log(f"Parsed {len(issues)} issues from JSON string ({vep_related_count} VEP-related)", node="indexer")
                         return issues
                 except json.JSONDecodeError:
-                    log("Could not parse issues string as JSON, returning raw data", node="indexer", level="DEBUG")
-                return [{"raw_data": issues_result[:15000]}]
+                    log("Could not parse issues string as JSON", node="indexer", level="DEBUG")
+                    return []
+                # Parsed as JSON but not a list (e.g. a dict wrapper we could
+                # not turn into issues): drop it rather than emit a fake entry.
+                log("Issues JSON string was not a list; returning no issues", node="indexer", level="WARNING")
+                return []
             elif isinstance(issues_result, list):
                 issues = []
                 for issue in issues_result:
@@ -873,7 +1033,11 @@ def index_enhancements_issues(days_back: int | None = 365) -> list[dict[str, Any
                 log(f"Indexed {len(issues)} issues ({vep_related_count} VEP-related)", node="indexer")
                 return issues
             else:
-                return [{"raw_data": str(issues_result)[:15000]}]
+                log(
+                    f"Unexpected issues_result type: {type(issues_result).__name__}",
+                    node="indexer", level="WARNING",
+                )
+                return []
                 
         except Exception as e:
             log(f"Error listing issues: {e}", node="indexer", level="WARNING")
@@ -887,61 +1051,12 @@ def index_enhancements_issues(days_back: int | None = 365) -> list[dict[str, Any
 
 
 def _extract_vep_issue_number(title: str, body: str) -> int | None:
-    """Extract VEP tracking issue number from PR title and body.
+    """Extract the VEP tracking issue number a PR references.
 
-    Priority order (structured declarations beat generic URL scanning):
-    1. Keyword declarations: "Tracking issue: #80", "VEP Tracker: #21"
-    2. Keyword + URL: "Tracking issue: .../issues/80"
-    3. VEP number in title: "VEP 165: ..."
-    4. Generic close keywords: "fixes #N", "closes #N"
-    5. Any enhancements issue URL (least reliable - catches footnotes/deps)
-
-    Returns:
-        Issue number or None
+    Thin wrapper over services.attribution.extract_tracking_issue, the single
+    unit-tested implementation of PR -> tracking-issue reference extraction.
     """
-    text_to_search = f"{title} {body}"
-    if not text_to_search.strip():
-        return None
-
-    # Pattern 1: Keyword declarations with inline number (most intentional)
-    keyword_patterns = [
-        r'tracking\s+issue[\s:]+#?(\d+)',
-        r'vep\s+tracker[\s:]+#?(\d+)',
-        r'tracker[\s:]+#?(\d+)',
-        r'vep\s+issue[\s:]+#?(\d+)',
-    ]
-    for pattern in keyword_patterns:
-        match = re.search(pattern, text_to_search, re.IGNORECASE)
-        if match:
-            return int(match.group(1))
-
-    # Pattern 2: Keyword followed by issue URL on the same line
-    keyword_url_pattern = re.compile(
-        r'(?:tracking\s+issue|vep\s+tracker|tracker|vep\s+issue)'
-        r'[\s:]+\S*github\.com/kubevirt/enhancements/issues/(\d+)',
-        re.IGNORECASE,
-    )
-    match = keyword_url_pattern.search(text_to_search)
-    if match:
-        return int(match.group(1))
-
-    # Pattern 3: VEP number in title
-    if title:
-        vep_title_match = re.search(r'VEP[- #]*0*(\d+)', title, re.IGNORECASE)
-        if vep_title_match:
-            return int(vep_title_match.group(1))
-
-    # Pattern 4: Generic close keywords
-    generic_match = re.search(r'(?:fixes|closes)[\s:]+#?(\d+)', text_to_search, re.IGNORECASE)
-    if generic_match:
-        return int(generic_match.group(1))
-
-    # Pattern 5: Any enhancements issue URL (fallback - may match footnotes/deps)
-    issue_url_match = re.search(r'github\.com/kubevirt/enhancements/issues/(\d+)', text_to_search)
-    if issue_url_match:
-        return int(issue_url_match.group(1))
-
-    return None
+    return extract_tracking_issue(title, body)
 
 
 def index_enhancements_prs(days_back: int | None = 365) -> list[dict[str, Any]]:
@@ -1426,6 +1541,88 @@ def index_kubevirt_prs(days_back: int | None = 365, fetch_reviews: bool = True) 
         return []
 
     return []
+
+
+def fetch_pr_metadata_by_number(pr_numbers: list[int], owner: str = "kubevirt", repo: str = "kubevirt") -> dict[int, dict[str, Any]]:
+    """Fetch real state/merged_at/base_ref metadata for a small explicit set of PR numbers.
+
+    Used to backfill metadata for impl PRs that are enumerated in a tracking
+    issue but absent from the bulk-indexed prs_index (e.g. beyond the fetch
+    window), so cycle-scoping filters can still apply to them.
+
+    Args:
+        pr_numbers: Explicit list of PR numbers to fetch.
+        owner: Repo owner (default "kubevirt").
+        repo: Repo name (default "kubevirt").
+
+    Returns:
+        Dict mapping pr_number -> {"state": str, "merged_at": str|None, "base_ref": str|None}.
+        PR numbers that fail to fetch are omitted from the result.
+    """
+    if not pr_numbers:
+        return {}
+
+    log(f"Fetching PR metadata for {len(pr_numbers)} widened impl PR(s): {sorted(pr_numbers)}", node="indexer")
+
+    try:
+        tools = get_mcp_tools_by_name("github")
+    except Exception as e:
+        log(f"Error getting MCP tools for PR metadata fetch: {e}", node="indexer", level="WARNING")
+        return {}
+
+    get_pr_tool = None
+    tool_names_to_try = ["pull_request_read", "mcp_GitHub_pull_request_read", "get_pull_request", "mcp_GitHub_get_pull_request"]
+    for tool in tools:
+        if tool.name in tool_names_to_try:
+            get_pr_tool = tool
+            break
+    if not get_pr_tool:
+        for tool in tools:
+            tool_name_lower = tool.name.lower()
+            if "pull_request" in tool_name_lower and ("read" in tool_name_lower or "get" in tool_name_lower):
+                get_pr_tool = tool
+                break
+
+    if not get_pr_tool:
+        log(f"Could not find pull_request_read/get_pull_request tool. Available tools: {[t.name for t in tools]}", node="indexer", level="WARNING")
+        return {}
+
+    is_consolidated = "pull_request_read" in get_pr_tool.name.lower()
+
+    result: dict[int, dict[str, Any]] = {}
+    for pr_num in pr_numbers:
+        try:
+            kwargs: dict[str, Any] = {"owner": owner, "repo": repo, "pullNumber": pr_num}
+            if is_consolidated:
+                kwargs["method"] = "get"
+            pr_result = _call_with_retry(get_pr_tool.func, **kwargs)
+
+            if isinstance(pr_result, str) and "Error calling tool" in pr_result:
+                log(f"Error fetching metadata for widened PR #{pr_num}: {pr_result[:200]}", node="indexer", level="WARNING")
+                continue
+
+            if isinstance(pr_result, str):
+                pr_result = json.loads(pr_result)
+            if isinstance(pr_result, str):
+                pr_result = json.loads(pr_result)
+
+            if not isinstance(pr_result, dict):
+                log(f"Unexpected get_pull_request result type for PR #{pr_num}: {type(pr_result)}", node="indexer", level="WARNING")
+                continue
+
+            is_merged = pr_result.get("merged", False) or (pr_result.get("merged_at") is not None)
+            state = "merged" if is_merged else pr_result.get("state", "")
+            merged_at = pr_result.get("merged_at")
+            base = pr_result.get("base")
+            base_ref = pr_result.get("base_ref") or (base.get("ref") if isinstance(base, dict) else None)
+
+            result[pr_num] = {"state": state, "merged_at": merged_at, "base_ref": base_ref}
+        except Exception as e:
+            log(f"Error fetching metadata for widened PR #{pr_num}: {e}", node="indexer", level="WARNING")
+            continue
+
+    log(f"Fetched metadata for {len(result)}/{len(pr_numbers)} widened impl PR(s)", node="indexer")
+    return result
 
 
 def index_enhancements_readme() -> dict[str, Any] | None:
@@ -2150,28 +2347,6 @@ def index_vep_pr_mappings(prs_index: list[dict[str, Any]] | None = None) -> dict
     return mappings
 
 
-def _extract_proposal_prs_from_issue(issue_body: str) -> list[int]:
-    """Extract proposal PR numbers from tracking issue body.
-
-    The tracking issue is the authoritative source for proposal PRs.
-    Looks for enhancements PR URLs in the issue body.
-
-    Returns:
-        List of PR numbers
-    """
-    if not issue_body:
-        return []
-
-    pr_numbers = set()
-
-    # Pattern for enhancements PR URLs (most reliable)
-    pr_url_pattern = re.compile(r'github\.com/kubevirt/enhancements/pull/(\d+)')
-    for match in pr_url_pattern.finditer(issue_body):
-        pr_numbers.add(int(match.group(1)))
-
-    return sorted(pr_numbers)
-
-
 def index_approved_vep_prs(prs_index: list[dict[str, Any]] | None = None) -> list[dict[str, Any]]:
     """Index PRs with 'approved-vep' label from kubevirt/kubevirt.
 
@@ -2654,22 +2829,28 @@ def create_indexed_context(days_back: int | None = 365, cache_max_age_minutes: i
     indexed_context["release_deadlines"] = release_info.get("release_deadlines", {}) if release_info else {}
     indexed_context["previous_release_code_freeze"] = release_info.get("previous_release_code_freeze") if release_info else None
 
-    # Compute cycle_start_date: earliest schedule date (primary) or prev CF + 14d (fallback)
+    # Compute cycle_start_date. The current cycle opens when the *previous*
+    # release hits Code Freeze (master reopens for the next release), so the
+    # previous release's Code Freeze is the authoritative boundary. The earliest
+    # schedule date is a poor proxy - it picks up unrelated rows (e.g. Kubernetes
+    # dependency dates) that predate the real cycle start - so it is only a
+    # fallback when the previous Code Freeze is unavailable.
     cycle_start_date = None
     deadlines = indexed_context.get("release_deadlines", {})
-    cycle_start_from_schedule = deadlines.get("cycle_start")
-    if cycle_start_from_schedule:
-        cycle_start_date = cycle_start_from_schedule
-        log(f"Cycle start date from schedule: {cycle_start_date}", node="indexer")
-    elif indexed_context["previous_release_code_freeze"]:
+    prev_cf = indexed_context.get("previous_release_code_freeze")
+    if prev_cf:
         try:
-            prev_cf = date.fromisoformat(indexed_context["previous_release_code_freeze"])
-            cycle_start_date = (prev_cf + timedelta(days=14)).isoformat()
-            log(f"Cycle start date from prev CF + 14d fallback: {cycle_start_date}", node="indexer")
+            cycle_start_date = date.fromisoformat(prev_cf).isoformat()
+            log(f"Cycle start date from previous release code freeze: {cycle_start_date}", node="indexer")
         except (ValueError, TypeError):
-            log("Could not compute cycle_start_date from previous_release_code_freeze", node="indexer", level="WARNING")
-    else:
-        log("No cycle_start_date available: no schedule dates and no previous CF", node="indexer", level="WARNING")
+            log("Could not parse previous_release_code_freeze for cycle_start_date", node="indexer", level="WARNING")
+    if not cycle_start_date:
+        cycle_start_from_schedule = deadlines.get("cycle_start")
+        if cycle_start_from_schedule:
+            cycle_start_date = cycle_start_from_schedule
+            log(f"Cycle start date fallback from earliest schedule date: {cycle_start_date}", node="indexer", level="WARNING")
+        else:
+            log("No cycle_start_date available: no previous CF and no schedule dates", node="indexer", level="WARNING")
     indexed_context["cycle_start_date"] = cycle_start_date
 
     # Log summary

--- a/tests/test_attribution.py
+++ b/tests/test_attribution.py
@@ -1,0 +1,134 @@
+"""Unit tests for deterministic PR -> VEP attribution.
+
+Fixtures are grounded in real kubevirt/enhancements + kubevirt/kubevirt data
+(the VEP 25 / 25.1 / 25.2 family and the VEP 349 vs 371 impl-PR cluster) that
+drove the WS1 attribution redesign.
+"""
+
+from services.attribution import (
+    extract_tracking_issue,
+    parse_enumerated_impl_prs,
+    resolve_impl_owner,
+)
+
+
+class TestExtractTrackingIssue:
+    def test_markdown_bold_tracking_issue_url(self):
+        # PR #398 - the "VEP 25 Extension" design PR. Belongs to VEP 25 only.
+        assert extract_tracking_issue(
+            "VEP 25 Extension: Improve Pull Mode Design",
+            "**Tracking issue**: https://github.com/kubevirt/enhancements/issues/25",
+        ) == 25
+
+    def test_tracking_issue_beats_footnote(self):
+        # PR #400 - declares tracking issue 399 (VEP 25.1) but also footnotes the
+        # parent VEP 25. The explicit tracking-issue line must win over the
+        # generic enhancements URL, so this is 399 - not 25.
+        body = (
+            "**Tracking issue**: https://github.com/kubevirt/enhancements/issues/399\n\n"
+            "This is an extension of https://github.com/kubevirt/enhancements/issues/25"
+        )
+        assert extract_tracking_issue("VEP 25.1: Multi-checkpoint", body) == 399
+
+    def test_sibling_proposal_prs(self):
+        assert extract_tracking_issue(
+            "VEP 25.2: Auto provision",
+            "**Tracking issue**: https://github.com/kubevirt/enhancements/issues/416",
+        ) == 416
+        assert extract_tracking_issue(
+            "VEP 323 proposal",
+            "**Tracking issue**: https://github.com/kubevirt/enhancements/issues/323",
+        ) == 323
+
+    def test_sub_vep_title_alone_does_not_truncate(self):
+        # "VEP 25.1" in a title must NOT collapse to 25 - that was the root of
+        # the #398-on-sibling contamination. With no explicit link -> unlinked.
+        assert extract_tracking_issue("VEP 25.1: Multi-checkpoint", "") is None
+
+    def test_whole_number_title_still_matches(self):
+        assert extract_tracking_issue("VEP 165: Something", "") == 165
+
+    def test_impl_pr_bare_enhancements_issue_url(self):
+        # The approved-vep bot's signal: a bare enhancements issue URL in an
+        # impl PR body. Kept as the last-resort pattern.
+        assert extract_tracking_issue(
+            "Add integration test framework",
+            "Implements https://github.com/kubevirt/enhancements/issues/371",
+        ) == 371
+
+    def test_keyword_inline_number(self):
+        assert extract_tracking_issue("Some PR", "Tracking issue: #80") == 80
+        assert extract_tracking_issue("Some PR", "VEP tracking issue: #349") == 349
+
+    def test_placeholder_rejected(self):
+        assert extract_tracking_issue(
+            "Some PR", "Closes kubevirt/enhancements#<vep_tracking_issue_number>"
+        ) is None
+        assert extract_tracking_issue(
+            "Some PR",
+            "Tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>",
+        ) is None
+
+    def test_empty_and_none(self):
+        assert extract_tracking_issue("", "") is None
+        assert extract_tracking_issue(None, None) is None
+
+
+class TestParseEnumeratedImplPrs:
+    def test_issue_371_enumerates_full_cluster(self):
+        # Real shape of issue #371's body: full kubevirt/kubevirt pull URLs,
+        # plus an enhancements proposal-PR URL and a bare #ref that must NOT be
+        # picked up as impl PRs.
+        body = (
+            "Design PR: https://github.com/kubevirt/enhancements/pull/348\n"
+            "Related: #18238\n"
+            "Impl PRs:\n"
+            "- https://github.com/kubevirt/kubevirt/pull/18726\n"
+            "- https://github.com/kubevirt/kubevirt/pull/18727\n"
+            "- https://github.com/kubevirt/kubevirt/pull/18728\n"
+            "- https://github.com/kubevirt/kubevirt/pull/18729\n"
+            "- https://github.com/kubevirt/kubevirt/pull/18730\n"
+            "- https://github.com/kubevirt/kubevirt/pull/18731\n"
+            "- https://github.com/kubevirt/kubevirt/pull/18841\n"
+        )
+        assert parse_enumerated_impl_prs(body) == {
+            18726, 18727, 18728, 18729, 18730, 18731, 18841,
+        }
+
+    def test_excludes_enhancements_pull_urls(self):
+        assert parse_enumerated_impl_prs(
+            "https://github.com/kubevirt/enhancements/pull/350"
+        ) == set()
+
+    def test_empty(self):
+        assert parse_enumerated_impl_prs("") == set()
+        assert parse_enumerated_impl_prs(None) == set()
+
+
+class TestResolveImplOwner:
+    def test_reciprocated(self):
+        # 18726 self-refs 371 and 371 lists it back -> confident.
+        assert resolve_impl_owner(371, {371}) == (371, False)
+
+    def test_unreciprocated_conflict_pr_wins_and_flags(self):
+        # 18727 self-refs 349 (copy-paste), 371 lists it. Neither reciprocates;
+        # trust the PR's own claim (349) but flag the conflict.
+        assert resolve_impl_owner(349, {371}) == (349, True)
+
+    def test_pr_only_claim_trusted(self):
+        # 18750 self-refs 25, no issue enumerates it -> 25, no conflict.
+        assert resolve_impl_owner(25, set()) == (25, False)
+
+    def test_pr_claim_beats_competing_enumeration(self):
+        # 18750 self-refs 25 even though 25.2 (416) lists it in a stray
+        # checkbox -> stays with 25, flagged.
+        assert resolve_impl_owner(25, {416}) == (25, True)
+
+    def test_issue_only(self):
+        assert resolve_impl_owner(None, {371}) == (371, False)
+
+    def test_multiple_issues_no_self_ref_ambiguous(self):
+        assert resolve_impl_owner(None, {371, 349}) == (None, True)
+
+    def test_unlinked(self):
+        assert resolve_impl_owner(None, set()) == (None, False)

--- a/tests/test_cache_load.py
+++ b/tests/test_cache_load.py
@@ -1,0 +1,31 @@
+"""Regression tests for _load_cached_index resilience.
+
+A stale cache file with a timezone-naive `cached_at` must not crash the whole
+run (it did: `datetime.now(UTC) - naive` raised TypeError, which the except
+clause failed to catch, taking the agent down on container restart).
+"""
+
+import json
+from datetime import UTC, datetime
+
+from services.indexer import _load_cached_index
+
+
+def test_naive_cached_at_regenerates_instead_of_crashing(tmp_path):
+    cache = tmp_path / "index_cache.json"
+    # tz-naive timestamp (no offset) - the shape that crashed startup.
+    cache.write_text(json.dumps({"cached_at": "2026-08-26T12:00:00", "foo": "bar"}))
+    assert _load_cached_index(cache, max_age_minutes=60) is None
+
+
+def test_fresh_aware_cache_loads(tmp_path):
+    cache = tmp_path / "index_cache.json"
+    cache.write_text(json.dumps({"cached_at": datetime.now(UTC).isoformat(), "foo": "bar"}))
+    result = _load_cached_index(cache, max_age_minutes=60)
+    assert result is not None
+    assert result.get("foo") == "bar"
+    assert "cached_at" not in result  # metadata stripped
+
+
+def test_missing_cache_returns_none(tmp_path):
+    assert _load_cached_index(tmp_path / "nope.json", max_age_minutes=60) is None

--- a/tests/test_issue_fetch_parsing.py
+++ b/tests/test_issue_fetch_parsing.py
@@ -1,0 +1,58 @@
+"""Unit tests for the MCP issue/page response parsing helpers in services.indexer.
+
+These are pure functions that normalize the various shapes MCP GitHub tools
+return (native dicts, JSON strings, double-encoded JSON strings, content
+wrappers, bare lists) into a consistent list-of-issues or dict form.
+"""
+
+import json
+
+from services.indexer import _coerce_page_to_dict, _unwrap_issues_dict
+
+
+class TestUnwrapIssuesDict:
+    def test_issues_key(self):
+        assert _unwrap_issues_dict({"issues": [{"number": 1}]}) == [{"number": 1}]
+
+    def test_items_key(self):
+        assert _unwrap_issues_dict({"items": [{"number": 1}]}) == [{"number": 1}]
+
+    def test_data_key(self):
+        assert _unwrap_issues_dict({"data": [{"number": 1}]}) == [{"number": 1}]
+
+    def test_content_json_string(self):
+        d = {"content": json.dumps([{"number": 2}])}
+        assert _unwrap_issues_dict(d) == [{"number": 2}]
+
+    def test_content_list_of_text_blocks(self):
+        d = {"content": [{"type": "text", "text": json.dumps([{"number": 3}])}]}
+        assert _unwrap_issues_dict(d) == [{"number": 3}]
+
+    def test_single_issue_object(self):
+        d = {"number": 7, "title": "x"}
+        assert _unwrap_issues_dict(d) == [d]
+
+    def test_unrecognized_shape_returns_none(self):
+        assert _unwrap_issues_dict({"foo": "bar"}) is None
+
+
+class TestCoercePageToDict:
+    def test_dict_passthrough(self):
+        d = {"issues": [{"number": 1}], "totalCount": 1}
+        assert _coerce_page_to_dict(d) is d
+
+    def test_json_string_of_dict(self):
+        d = {"issues": [{"number": 1}]}
+        assert _coerce_page_to_dict(json.dumps(d)) == d
+
+    def test_double_encoded_json_string(self):
+        d = {"issues": [{"number": 1}]}
+        double_encoded = json.dumps(json.dumps(d))
+        assert _coerce_page_to_dict(double_encoded) == d
+
+    def test_bare_list_wrapped(self):
+        items = [{"number": 1}, {"number": 2}]
+        assert _coerce_page_to_dict(items) == {"issues": items}
+
+    def test_plain_error_string_returns_none(self):
+        assert _coerce_page_to_dict("failed: 403") is None

--- a/tests/test_summary_table_attribution.py
+++ b/tests/test_summary_table_attribution.py
@@ -1,0 +1,205 @@
+"""End-to-end attribution test for build_vep_summary_table.
+
+Reconstructs the VEP 25 family and the VEP 349/371 impl-PR cluster as a fake
+indexed_context and asserts the exact Proposal/Impl PR columns the board should
+show after the WS1 fix:
+
+  - VEP 25   keeps proposal #398 (drops #400) and its five impl PRs incl. #18750
+  - VEP 25.1 gets proposal #400 (no longer #398), no impl PRs
+  - VEP 25.2 gets proposal #417 (no longer #398), no impl PRs (18750 stays on 25)
+  - VEP 371  gets the reciprocated impl PRs #18726/#18841
+  - VEP 349  keeps the impl PRs that self-declare it (#18727-31), flagged as
+    conflicts (PR-wins-on-unreciprocated-conflict decision)
+"""
+
+from types import SimpleNamespace
+
+from nodes.alert_formatting import build_vep_summary_table
+
+
+def _vep(issue_id, name, title):
+    return SimpleNamespace(tracking_issue_id=issue_id, name=name, title=title, analysis=None)
+
+
+def _enh_pr(number, vep_issue_number):
+    return {"number": number, "vep_issue_number": vep_issue_number,
+            "state": "open", "merged_at": None}
+
+
+def _kv_pr(number, self_ref):
+    return {
+        "number": number,
+        "vep_issue_number": self_ref,
+        "state": "open",
+        "merged_at": None,
+        "base_ref": "main",
+        "url": f"https://github.com/kubevirt/kubevirt/pull/{number}",
+        "title": f"kubevirt PR {number}",
+        "body_preview": "",
+    }
+
+
+def _kv_url(number):
+    return f"https://github.com/kubevirt/kubevirt/pull/{number}"
+
+
+def _build_context():
+    enhancements_prs = [
+        _enh_pr(398, 25),
+        _enh_pr(400, 399),
+        _enh_pr(417, 416),
+        _enh_pr(324, 323),
+    ]
+    prs_index = [
+        _kv_pr(18313, 25), _kv_pr(18416, 25), _kv_pr(18537, 25),
+        _kv_pr(18725, 25), _kv_pr(18750, 25),
+        _kv_pr(18726, 371), _kv_pr(18841, 371),
+        _kv_pr(18727, 349), _kv_pr(18728, 349), _kv_pr(18729, 349),
+        _kv_pr(18730, 349), _kv_pr(18731, 349),
+    ]
+    issues_index = [
+        {"number": 25, "body": "VEP 25 tracking issue"},
+        {"number": 399, "body": "VEP 25.1 tracking issue"},
+        # 25.2's body mislabels an impl PR under a checkbox - must NOT steal it
+        # from VEP 25 (18750 self-declares issue 25).
+        {"number": 416, "body": f"VEP 25.2. VEP PRs: {_kv_url(18750)}"},
+        # 349 (EFI/vTPM) does not enumerate any of the cluster PRs.
+        {"number": 349, "body": "Block-mode backend storage VEP. No impl PRs listed."},
+        # 371 enumerates the whole cluster.
+        {"number": 371, "body": "Impl PRs: " + " ".join(
+            _kv_url(n) for n in (18726, 18727, 18728, 18729, 18730, 18731, 18841))},
+    ]
+    return {
+        "enhancements_prs": enhancements_prs,
+        "prs_index": prs_index,
+        "issues_index": issues_index,
+        "cycle_start_date": "2026-06-24",
+        "release_deadlines": {},
+        "current_release": "v1.10",
+    }
+
+
+def _rows_by_vep(veps):
+    rows = build_vep_summary_table(veps, indexed_context=_build_context())
+    return {r["vep_number"]: r for r in rows}
+
+
+def _numbers(prs):
+    return {p["number"] for p in prs}
+
+
+def test_proposal_attribution_is_reference_based():
+    veps = [
+        _vep(25, "vep-0025", "VEP 25"),
+        _vep(399, "vep-0025", "VEP 25.1"),
+        _vep(416, "vep-0025", "VEP 25.2"),
+    ]
+    rows = _rows_by_vep(veps)
+    # VEP 25 keeps its own design PR #398, and NO LONGER #400.
+    assert _numbers(rows[25]["proposal_prs"]) == {398}
+    # Sibling sub-VEPs drop the contaminating #398 and get their own PRs.
+    assert _numbers(rows[399]["proposal_prs"]) == {400}
+    assert _numbers(rows[416]["proposal_prs"]) == {417}
+
+
+def test_impl_attribution_one_pr_one_vep():
+    veps = [
+        _vep(25, "vep-0025", "VEP 25"),
+        _vep(399, "vep-0025", "VEP 25.1"),
+        _vep(416, "vep-0025", "VEP 25.2"),
+        _vep(371, "vep-0371", "VEP 371"),
+        _vep(349, "vep-0349", "VEP 349"),
+    ]
+    rows = _rows_by_vep(veps)
+    # VEP 25's five impl PRs, including #18750 (which 25.2 mislabels).
+    assert _numbers(rows[25]["impl_prs"]) == {18313, 18416, 18537, 18725, 18750}
+    assert _numbers(rows[399]["impl_prs"]) == set()
+    assert _numbers(rows[416]["impl_prs"]) == set()
+    # Reciprocated impl PRs land on 371; the copy-paste-declared ones stay on
+    # their self-declared 349 (PR-wins-on-conflict). Each PR appears once.
+    assert _numbers(rows[371]["impl_prs"]) == {18726, 18841}
+    assert _numbers(rows[349]["impl_prs"]) == {18727, 18728, 18729, 18730, 18731}
+
+
+def test_widen_attributes_enumerated_pr_absent_from_prs_index():
+    """A tracking issue can enumerate an impl PR that never showed up in
+    prs_index (e.g. beyond the fetch window). The widen pass must still
+    attribute it to the sole enumerating in-scope VEP, but a PR enumerated by
+    two in-scope issues (ambiguous, no self-ref to break the tie) must stay
+    unlinked rather than being guessed onto either.
+    """
+    context = {
+        "enhancements_prs": [],
+        "prs_index": [],
+        "issues_index": [
+            {"number": 900, "body": f"Impl PRs: {_kv_url(99999)}"},
+            {"number": 901, "body": f"Impl PRs: {_kv_url(88888)}"},
+            {"number": 902, "body": f"Impl PRs: {_kv_url(88888)}"},
+        ],
+        "cycle_start_date": "2026-06-24",
+        "release_deadlines": {},
+        "current_release": "v1.10",
+    }
+    veps = [
+        _vep(900, "vep-0900", "VEP 900"),
+        _vep(901, "vep-0901", "VEP 901"),
+        _vep(902, "vep-0902", "VEP 902"),
+    ]
+    rows = {r["vep_number"]: r for r in build_vep_summary_table(veps, indexed_context=context)}
+
+    # Unambiguous: 99999 is enumerated only by 900, though absent from prs_index.
+    assert 99999 in _numbers(rows[900]["impl_prs"])
+
+    # Ambiguous: 88888 is enumerated by both 901 and 902, with no self-ref and
+    # absent from prs_index -> must not be guessed onto either.
+    assert 88888 not in _numbers(rows[901]["impl_prs"])
+    assert 88888 not in _numbers(rows[902]["impl_prs"])
+
+
+def test_widen_fetches_real_metadata_and_applies_cycle_filters():
+    """Widened impl PRs (enumerated but absent from prs_index) must be run
+    through the same cycle-scoping filters as indexed PRs, using real
+    metadata from the injected fetcher - not silently included with
+    _state=None/_merged_at=None.
+    """
+    context = {
+        "enhancements_prs": [],
+        "prs_index": [],
+        "issues_index": [
+            {"number": 950, "body": f"Impl PRs: {_kv_url(77001)} {_kv_url(77002)}"},
+        ],
+        "cycle_start_date": "2026-06-24",
+        "release_deadlines": {},
+        "current_release": "v1.10",
+    }
+    veps = [_vep(950, "vep-0950", "VEP 950")]
+
+    def fake_fetcher(nums):
+        assert nums == [77001, 77002]
+        return {
+            # Closed, never merged -> must be filtered out (closed-unmerged filter).
+            77001: {"state": "closed", "merged_at": None, "base_ref": "main"},
+            # Merged after cycle start on main -> must stay.
+            77002: {"state": "merged", "merged_at": "2026-07-01T00:00:00Z", "base_ref": "main"},
+        }
+
+    rows = {r["vep_number"]: r for r in build_vep_summary_table(veps, indexed_context=context, pr_metadata_fetcher=fake_fetcher)}
+    impl_numbers = _numbers(rows[950]["impl_prs"])
+    assert 77001 not in impl_numbers
+    assert 77002 in impl_numbers
+
+
+def test_no_pr_attributed_to_more_than_one_vep():
+    veps = [
+        _vep(25, "vep-0025", "VEP 25"),
+        _vep(399, "vep-0025", "VEP 25.1"),
+        _vep(416, "vep-0025", "VEP 25.2"),
+        _vep(371, "vep-0371", "VEP 371"),
+        _vep(349, "vep-0349", "VEP 349"),
+    ]
+    rows = _rows_by_vep(veps)
+    seen = []
+    for r in rows.values():
+        seen += [p["number"] for p in r["impl_prs"]]
+        seen += [p["number"] for p in r["proposal_prs"]]
+    assert len(seen) == len(set(seen)), f"PR attributed to multiple VEPs: {seen}"


### PR DESCRIPTION
## What this PR does

Reworks how the agent attributes GitHub PRs to VEPs and scopes them to the current release cycle.

- Reference-based attribution (one PR → at most one VEP): proposal and impl PRs are attributed strictly via the PR's tracking-issue reference and the tracking issue's own enumerated PR list (mirroring the approved-vep bot), replacing the title/issue-body scanning that caused double- and mis-attribution — e.g. enhancements #398 wrongly shown on VEP 25.1 and 25.2.
- Complete issue fetch: the enhancements issue list is cursor-paginated; the indexer now follows pageInfo.endCursor to fetch every issue instead of capping at the ~30 newest, so older VEPs' enumerated impl PRs are no longer lost.
- Cycle scoping for enumerated-but-unfetched impl PRs: their real state/merged_at/base_ref is fetched and run through the same cycle filters (closed-unmerged, backport, pre-cycle-merged), so historical/backported/closed PRs no longer ghost onto the current board.
- Adds unit tests for attribution, issue-fetch parsing, and cycle filtering, plus an --attribution-dump flag that runs indexer+attribution only (no LLM/board writes) for deterministic validation.
