### PR TITLE
Fix scheduler starving board/alert tasks when sheet updates fail

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,6 +1,3 @@
-Exit code: 0
-
---- stdout ---
 #!/usr/bin/env bash
 set -euo pipefail
 cd "$(dirname "$0")"

--- a/nodes/scheduler.py
+++ b/nodes/scheduler.py
@@ -214,28 +214,17 @@ def scheduler_node(state: VEPState) -> Any:
                     next_tasks.append("run_monitoring")
                 # Note: update_sheets and alert_summary will be scheduled after analyze_combined completes
     
-    # Also check if sheets_need_update flag is set (from analyze_combined)
-    # Only add if VEPs have been analyzed (or if skip_monitoring is enabled)
-    sheets_need_update = state.get("sheets_need_update", False)
-    if sheets_need_update and "update_sheets" not in next_tasks:
-        if not veps_need_analysis or skip_monitoring:
-            log("sheets_need_update flag is set, adding update_sheets to queue", node="scheduler")
-            next_tasks.append("update_sheets")
-        else:
-            log("sheets_need_update flag is set, but VEPs need analysis first - will schedule after analyze_combined", node="scheduler")
-    
-    # After analyze_combined completes, schedule update_sheets, update_project_board, and alert_summary
-    # But only if they haven't run since analyze_combined completed
+    # Schedule post-analysis tasks. IMPORTANT ORDERING: the graph router runs
+    # only next_tasks[0] each tick and then rebuilds this list, so list order is
+    # effectively task priority. update_project_board and alert_summary must be
+    # queued BEFORE update_sheets - otherwise a persistently-failing update_sheets
+    # (which keeps sheets_need_update=True) sits at index 0 forever and starves
+    # the board and alerts.
     analyze_combined_time = last_check_times.get("analyze_combined")
+    update_sheets_time = last_check_times.get("update_sheets")
     if analyze_combined_time:
-        update_sheets_time = last_check_times.get("update_sheets")
         update_board_time = last_check_times.get("update_project_board")
         alert_summary_time = last_check_times.get("alert_summary")
-
-        # Schedule update_sheets if it hasn't run since analyze_combined
-        if "update_sheets" not in next_tasks and (update_sheets_time is None or update_sheets_time < analyze_combined_time):
-            log("analyze_combined completed, scheduling update_sheets", node="scheduler")
-            next_tasks.append("update_sheets")
 
         # Schedule update_project_board if it hasn't run since analyze_combined
         if "update_project_board" not in next_tasks and not state.get("skip_update_board", False) and (update_board_time is None or update_board_time < analyze_combined_time):
@@ -246,6 +235,25 @@ def scheduler_node(state: VEPState) -> Any:
         if "alert_summary" not in next_tasks and (alert_summary_time is None or alert_summary_time < analyze_combined_time):
             log("analyze_combined completed, scheduling alert_summary", node="scheduler")
             next_tasks.append("alert_summary")
+
+        # Schedule update_sheets LAST, and only once per analysis epoch. Gating on
+        # "hasn't run since analyze_combined" means a failing sheets write retries
+        # on the NEXT full cycle instead of tight-looping at index 0 every tick.
+        if "update_sheets" not in next_tasks and (update_sheets_time is None or update_sheets_time < analyze_combined_time):
+            log("analyze_combined completed, scheduling update_sheets", node="scheduler")
+            next_tasks.append("update_sheets")
+
+    # Skip-monitoring path: analyze_combined never runs, so the block above is
+    # inert. Fall back to the sheets_need_update flag ONLY when analysis has never
+    # completed (analyze_combined_time is None), keeping update_sheets after any
+    # board/alert tasks already queued this tick.
+    sheets_need_update = state.get("sheets_need_update", False)
+    if sheets_need_update and "update_sheets" not in next_tasks and not analyze_combined_time:
+        if not veps_need_analysis or skip_monitoring:
+            log("sheets_need_update flag is set, adding update_sheets to queue", node="scheduler")
+            next_tasks.append("update_sheets")
+        else:
+            log("sheets_need_update flag is set, but VEPs need analysis first - will schedule after analyze_combined", node="scheduler")
     
     # Log scheduling decision
     if next_tasks:

--- a/services/mcp_factory.py
+++ b/services/mcp_factory.py
@@ -76,6 +76,7 @@ def _create_args_schema_from_json_schema(tool_name: str, json_schema: dict[str, 
     This ensures proper type information is available for Gemini's function calling.
     """
     if not json_schema or 'properties' not in json_schema:
+        log(f"No flat 'properties' in JSON schema for tool '{tool_name}' - cannot build typed args_schema; LLM will get a generic kwargs schema and may send empty args", node="mcp_factory", level="WARNING")
         return None
 
     # Fix the schema for Gemini compatibility
@@ -126,6 +127,7 @@ def _create_args_schema_from_json_schema(tool_name: str, json_schema: dict[str, 
             field_definitions[param_name] = (python_type | None, Field(default=None, description=param_desc))
 
     if not field_definitions:
+        log(f"No field definitions built for tool '{tool_name}' - cannot build typed args_schema; LLM will get a generic kwargs schema and may send empty args", node="mcp_factory", level="WARNING")
         return None
 
     # Create model with a unique name based on tool name
@@ -133,7 +135,7 @@ def _create_args_schema_from_json_schema(tool_name: str, json_schema: dict[str, 
     try:
         return create_model(model_name, **field_definitions)
     except Exception as e:
-        log(f"Failed to create args_schema for {tool_name}: {e}", node="mcp_factory", level="DEBUG")
+        log(f"Failed to create args_schema for {tool_name}: {e}", node="mcp_factory", level="WARNING")
         return None
 
 # ExceptionGroup is available in Python 3.11+ as a built-in

--- a/tests/test_scheduler_starvation.py
+++ b/tests/test_scheduler_starvation.py
@@ -1,0 +1,97 @@
+"""Regression tests for scheduler starvation of update_project_board/alert_summary.
+
+Bug: the graph router runs only next_tasks[0] per tick, then scheduler_node
+rebuilds next_tasks from scratch. update_sheets used to be appended before
+board/alerts and was re-queued unconditionally whenever sheets_need_update was
+set - a persistently-failing sheets write kept it at index 0 forever, starving
+update_project_board and alert_summary. The fix reorders the queue (board,
+alerts, then sheets) and gates update_sheets to once per analyze_combined
+epoch.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+from nodes.scheduler import scheduler_node
+
+NOW = datetime.now(UTC)
+ANALYZE_TIME = NOW - timedelta(minutes=5)
+FETCH_TIME = ANALYZE_TIME - timedelta(minutes=10)  # fetch ran before analyze -> no re-analysis needed
+
+
+def _base_state(**overrides):
+    state = {
+        "immediate_start": True,
+        "veps": [{"number": 1}],
+        "last_check_times": {
+            "fetch_veps": FETCH_TIME,
+            "analyze_combined": ANALYZE_TIME,
+        },
+    }
+    state.update(overrides)
+    return state
+
+
+def test_board_scheduled_before_sheets_when_sheets_pending():
+    state = _base_state(sheets_need_update=True)
+    result = scheduler_node(state)
+    next_tasks = result["next_tasks"]
+
+    assert "update_project_board" in next_tasks
+    assert "alert_summary" in next_tasks
+    assert "update_sheets" in next_tasks
+    assert next_tasks.index("update_project_board") < next_tasks.index("update_sheets")
+    assert next_tasks.index("alert_summary") < next_tasks.index("update_sheets")
+
+
+def test_failing_sheets_does_not_requeue_after_it_ran_this_epoch():
+    last_check_times = {
+        "fetch_veps": FETCH_TIME,
+        "analyze_combined": ANALYZE_TIME,
+        "update_sheets": ANALYZE_TIME + timedelta(minutes=1),
+        "update_project_board": ANALYZE_TIME + timedelta(minutes=1),
+        "alert_summary": ANALYZE_TIME + timedelta(minutes=1),
+    }
+    state = _base_state(last_check_times=last_check_times, sheets_need_update=True)
+    result = scheduler_node(state)
+    next_tasks = result["next_tasks"]
+
+    assert "update_sheets" not in next_tasks
+
+
+def test_sheets_scheduled_once_per_epoch_when_not_yet_run():
+    last_check_times = {
+        "fetch_veps": FETCH_TIME,
+        "analyze_combined": ANALYZE_TIME,
+        "update_project_board": ANALYZE_TIME + timedelta(minutes=1),
+        "alert_summary": ANALYZE_TIME + timedelta(minutes=1),
+    }
+    state = _base_state(last_check_times=last_check_times)
+    result = scheduler_node(state)
+    next_tasks = result["next_tasks"]
+
+    assert "update_sheets" in next_tasks
+
+
+def test_board_not_scheduled_when_skip_update_board():
+    state = _base_state(sheets_need_update=True, skip_update_board=True)
+    result = scheduler_node(state)
+    next_tasks = result["next_tasks"]
+
+    assert "update_project_board" not in next_tasks
+    assert "update_sheets" in next_tasks
+    assert "alert_summary" in next_tasks
+
+
+def test_skip_monitoring_uses_flag_path():
+    last_check_times = {
+        "fetch_veps": FETCH_TIME,
+    }
+    state = _base_state(
+        last_check_times=last_check_times,
+        skip_monitoring=True,
+        sheets_need_update=True,
+    )
+    result = scheduler_node(state)
+    next_tasks = result["next_tasks"]
+
+    assert "update_sheets" in next_tasks


### PR DESCRIPTION
A persistently-failing `update_sheets` kept `sheets_need_update` set, so the scheduler re-queued it ahead of `update_project_board` and `alert_summary` on every tick and those never ran — the project board went stale (verified in prod: board writes were starved for 1.5h). Fixes:

- Order board + alerts ahead of `update_sheets`, and retry sheets at most once per analysis cycle (the router only runs `next_tasks[0]`, so order = priority).
- Log at WARNING when a tool's typed arg schema can't be built (silent fallback let the LLM send empty tool args).
- Remove stray output lines accidentally committed into `deploy.sh`.

Verified in prod: board now writes 79/79 items, alerts run, no tight-loop.

Added 5 scheduler tests; full suite 44 passed, ruff clean.